### PR TITLE
Catch any error and exception and display them in JSON.

### DIFF
--- a/php/ErrorHandler.php
+++ b/php/ErrorHandler.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @author Adirelle <adirelle@gmail.com>
+ *
+ * Output PHP errors and exceptions in JSON.
+ **/
+
+class ErrorHandler
+{
+    static private $reserve;
+
+    /**
+     * Set up error handling.
+     */
+    public static function register()
+    {
+        // Keep some room in case of memory exhaustion
+        self::$reserve = str_repeat(' ', 4096);
+
+        // Ensure nothing will be send to stdout
+        ini_set('display_errors', false);
+        ini_set('log_errors', false);
+
+        // Register our handlers
+        register_shutdown_function('ErrorHandler::onShutdown');
+        set_error_handler('ErrorHandler::onError');
+        set_exception_handler('ErrorHandler::onException');
+    }
+
+    /**
+     * @throws ErrorException on any error.
+     */
+    public static function onError($code, $message, $file, $line, $context)
+    {
+        throw new \ErrorException($message, $code, 1, $file, $line);
+    }
+
+    /**
+     * Display uncaught exception in JSON.
+     *
+     * @param \Exception $exception
+     */
+    public static function onException(\Exception $exception)
+    {
+        die(
+            json_encode(
+                array('error' =>
+                    array(
+                        'message' => $exception->getMessage(),
+                        'code' => $exception->getCode(),
+                        'file' => $exception->getFile(),
+                        'line' => $exception->getLine(),
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * Display any fatal error in JSON.
+     */
+    public static function onShutdown()
+    {
+        self::$reserve = null;
+
+        $error = error_get_last();
+        if ($error !== null) {
+            die(json_encode(array('error' => $error)));
+        }
+    }
+}

--- a/php/parser.php
+++ b/php/parser.php
@@ -6,6 +6,9 @@
  * This script returns all functions, classes & methods in the given directory.
  * Internals and user's one
  **/
+require_once(__DIR__ . '/ErrorHandler.php');
+ErrorHandler::register();
+
 require_once(__DIR__ . '/tmp.php');
 require_once(__DIR__ . '/Config.php');
 require_once(__DIR__ . '/services/Tools.php');
@@ -31,17 +34,6 @@ $commands = array(
 );
 
 /**
-* Function called when a fatal occured
-*/
-function fatal_handler() {
-    $error = error_get_last();
-
-    if ($error !== NULL) {
-        die(json_encode(array('error' => $error)));
-    }
-}
-
-/**
 * Print an error
 * @param string $message
 */
@@ -52,8 +44,6 @@ function show_error($message) {
 if (count($argv) < 3) {
     die('Usage : php parser.php <dirname> <command> <args>');
 }
-
-register_shutdown_function('fatal_handler');
 
 $project = $argv[1];
 $command = $argv[2];


### PR DESCRIPTION
Properly handles all errors, and avoid outputting non-JSON text whatever is configured in php.ini.