### PR TITLE
Fixes php subcommand invocations.

### DIFF
--- a/php/providers/ClassMapRefresh.php
+++ b/php/providers/ClassMapRefresh.php
@@ -64,11 +64,11 @@ class ClassMapRefresh extends Tools implements ProviderInterface
 
     protected function buildIndexClass($class)
     {
-        $ret = exec(sprintf('%s %s/../parser.php %s --class %s',
-            Config::get('php'),
-            __DIR__,
-            Config::get('projectPath'),
-            str_replace('\\', '\\\\', $class)
+        $ret = exec(sprintf('%s %s %s --class %s',
+            escapeshellarg(Config::get('php')),
+            escapeshellarg(__DIR__ . '/../parser.php'),
+            escapeshellarg(Config::get('projectPath')),
+            escapeshellarg($class)
         ));
 
         if (false === $value = json_decode($ret, true)) {

--- a/php/providers/ClassesProvider.php
+++ b/php/providers/ClassesProvider.php
@@ -16,11 +16,11 @@ class ClassesProvider extends Tools implements ProviderInterface
 
         $mapping = array();
         foreach ($this->getClassMap(true) as $class => $filePath) {
-            $ret = exec(sprintf('%s %s/../parser.php %s --class %s',
-                Config::get('php'),
-                __DIR__,
-                Config::get('projectPath'),
-                str_replace('\\', '\\\\', $class)
+            $ret = exec(sprintf('%s %s %s --class %s',
+                escapeshellarg(Config::get('php')),
+                escapeshellarg(__DIR__ . '/../parser.php'),
+                escapeshellarg(Config::get('projectPath')),
+                escapeshellarg($class)
             ));
 
             if (false === $value = json_decode($ret, true)) {

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -18,7 +18,11 @@ abstract class Tools
     {
         if (empty($this->classMap) || $force) {
             if (Config::get('classmap_file') && !file_exists(Config::get('classmap_file')) || $force) {
-                exec(Config::get('composer') . ' -d=' . Config::get('projectPath') .' dump-autoload --optimize');
+                exec(sprintf('%s %s dump-autoload --optimize --quiet --no-interaction --working-dir=%s 2>&1',
+                    escapeshellarg(Config::get('php')),
+                    escapeshellarg(Config::get('composer')),
+                    escapeshellarg(Config::get('projectPath'))
+                ));
             }
 
             if (Config::get('classmap_file')) {


### PR DESCRIPTION
Properly escape all arguments passed to exec(), and also invoke composer using the php binary.

This allows the package to work on Windows, even with paths containing spaces.