### PR TITLE
Fixes to multi line goto and others

### DIFF
--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -52,7 +52,16 @@ class GotoFunction extends AbstractGoto
         methods = proxy.methods(calledClass)
         if methods.names.indexOf(term) == -1
             return
-        parentClass = methods.values[term].declaringClass;
+        value = methods.values[term]
+        parentClass = ''
+        if value instanceof Array
+            for val in value
+                if val.isMethod
+                    parentClass = val.declaringClass
+                    break
+        else
+            parentClass = value.declaringClass;
+
         classMap = proxy.autoloadClassMap()
 
         atom.workspace.open(classMap[parentClass], {

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -29,13 +29,13 @@ class GotoFunction extends AbstractGoto
     gotoFromWord: (editor, term) ->
         proxy = require '../services/php-proxy.coffee'
         bufferPosition = editor.getCursorBufferPosition()
-        fullCall = @parser.getFullWordFromBufferPosition(editor, bufferPosition)
+        fullCall = @parser.getStackClasses(editor, bufferPosition)
         calledClass = ''
         splitter = '->'
-        if fullCall.indexOf('->') != -1
-            calledClass = @parser.parseElements(editor, bufferPosition, fullCall.split('->'))
+        if fullCall.length > 1
+            calledClass = @parser.parseElements(editor, bufferPosition, fullCall)
         else
-            parts = fullCall.split('::')
+            parts = fullCall[0].trim().split('::')
             splitter = '::'
             if parts[0] == 'parent'
                 calledClass = @parser.getParentClass(editor)

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -6,7 +6,7 @@ class GotoFunction extends AbstractGoto
 
     hoverEventSelectors: '.function-call'
     clickEventSelectors: '.function-call'
-    gotoRegex: /^\$?\w+((->|::)\w+)+/
+    gotoRegex: /^(\$\w+)?((->|::)\w+)+/
 
     ###*
      * Initialisation of Gotos

--- a/lib/providers/autocomplete-provider.coffee
+++ b/lib/providers/autocomplete-provider.coffee
@@ -58,6 +58,12 @@ class AutocompleteProvider extends AbstractProvider
 
     return suggestions
 
+  ###*
+   * Adds the suggestion the the suggestions array.
+   * @param {string} word        The word being currently typed.
+   * @param {object} element     The object returns from proxy.methods.
+   * @param {array} suggestions  An array of suggestions for the current word.
+  ###
   addSuggestion: (word, element, suggestions) ->
     returnValues = element.args.return.split('\\')
 

--- a/lib/providers/autocomplete-provider.coffee
+++ b/lib/providers/autocomplete-provider.coffee
@@ -50,24 +50,32 @@ class AutocompleteProvider extends AbstractProvider
     suggestions = []
     for word in words
       element = @methods.values[word]
-
-      returnValues = element.args.return.split('\\')
-
-      # Methods
-      if element.isMethod
-        suggestions.push
-          text: word,
-          type: 'method',
-          snippet: @getFunctionSnippet(word, element.args),
-          leftLabel: returnValues[returnValues.length - 1]
-          description: if element.args.descriptions.short? then element.args.descriptions.short else ''
-
-      # Constants and public properties
+      if element instanceof Array
+        for ele in element
+          suggestions = @addSuggestion(word, ele, suggestions)
       else
-        suggestions.push
-          text: word,
-          type: 'property'
-          leftLabel: returnValues[returnValues.length - 1]
-          description: if element.args.descriptions.short? then element.args.descriptions.short else ''
+        suggestions = @addSuggestion(word, element, suggestions)
+
+    return suggestions
+
+  addSuggestion: (word, element, suggestions) ->
+    returnValues = element.args.return.split('\\')
+
+    # Methods
+    if element.isMethod
+      suggestions.push
+        text: word,
+        type: 'method',
+        snippet: @getFunctionSnippet(word, element.args),
+        leftLabel: returnValues[returnValues.length - 1]
+        description: if element.args.descriptions.short? then element.args.descriptions.short else ''
+
+    # Constants and public properties
+    else
+      suggestions.push
+        text: word,
+        type: 'property'
+        leftLabel: returnValues[returnValues.length - 1]
+        description: if element.args.descriptions.short? then element.args.descriptions.short else ''
 
     return suggestions

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -32,12 +32,12 @@ module.exports =
       # a class (see on top of the file)
       if name == ''
         for classDeclaration in classDeclarations
-          if line.indexOf(classDeclaration) == 0
+          if line.toLowerCase().indexOf(classDeclaration) == 0
             line = line.substring(classDeclaration.length, line.length).trim()
 
             name = line.split(' ')[0]
       else
-        if line.indexOf(namespaceDeclaration) != -1
+        if line.toLowerCase().indexOf(namespaceDeclaration) != -1
           line = line.replace('<?php', '').trim()
           line = line.substring(namespaceDeclaration.length, line.length).trim()
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -32,12 +32,12 @@ module.exports =
       # a class (see on top of the file)
       if name == ''
         for classDeclaration in classDeclarations
-          if line.toLowerCase().indexOf(classDeclaration) == 0
+          if line.indexOf(classDeclaration) == 0
             line = line.substring(classDeclaration.length, line.length).trim()
 
             name = line.split(' ')[0]
       else
-        if line.toLowerCase().indexOf(namespaceDeclaration) != -1
+        if line.indexOf(namespaceDeclaration) != -1
           line = line.replace('<?php', '').trim()
           line = line.substring(namespaceDeclaration.length, line.length).trim()
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -246,8 +246,9 @@ module.exports =
   ###
   parseStackClass: (text) ->
     # Remove parenthesis content
-    regx = /\((?:[^\])\(\)]+|(?:[^\(\)\])]*\([^\(\)\])]*\)[^\)]*))*\)*/g
-    text = text.replace regx, ""
+    regx = /\((?:[^)\(\)]+|(?:[^\(\)\])]*\([^\(\)\])]*\)[^\)]*))*\)*/g
+    text = text.replace regx, (match) =>
+        return '()'
 
     # Get the full text
     return [] if not text

--- a/php/providers/AutocompleteProvider.php
+++ b/php/providers/AutocompleteProvider.php
@@ -11,9 +11,13 @@ class AutocompleteProvider extends Tools implements ProviderInterface
     {
         $class = $args[0];
         $name  = $args[1];
-
+        $isMethod = false;
         if (strpos($class, '\\') == 0) {
             $class = substr($class, 1);
+        }
+        if (strpos($name, '()') > -1) {
+            $isMethod = true;
+            $name = str_replace('()', '', $name);
         }
 
         $classMap = $this->getClassMap();
@@ -25,11 +29,21 @@ class AutocompleteProvider extends Tools implements ProviderInterface
                 'values' => array()
             );
         }
+        $values = $data['values'][$name];
+        if (!isset($data['values'][$name]['isMethod'])) {
+            foreach ($data['values'][$name] as $value) {
+                if ($value['isMethod'] && $isMethod) {
+                    $values = $value;
+                } elseif (!$value['isMethod'] && !$isMethod) {
+                    $values = $value;
+                }
+            }
+        }
 
-        $returnValue = $data['values'][$name]['args']['return'];
+        $returnValue = $values['args']['return'];
         if ($returnValue == '$this' || $returnValue == 'self') {
             return $data;
-        } else if (ucfirst($returnValue) === $returnValue) {
+        } elseif (ucfirst($returnValue) === $returnValue) {
             $parser = new FileParser($classMap[$class]);
 
             $found = false;

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -121,14 +121,14 @@ abstract class Tools
         foreach ($attributes as $attribute) {
             if (!in_array($attribute->getName(), $data['names'])) {
                 $data['names'][] = $attribute->getName();
-                $data['values'][$attribute->getName()] = array();
+                $data['values'][$attribute->getName()] = null;
             }
 
             $parser = new DocParser();
             $return = $parser->get($className, 'property', $attribute->getName(), array(DocParser::VAR_TYPE));
             $descriptions = $parser->get($className, 'property', $attribute->getName(), array(DocParser::DESCRIPTION));
 
-            $data['values'][$attribute->getName()] = array(
+            $attributesValues = array(
                 'isMethod' => false,
                 'isPublic' => $attribute->isPublic(),
                 'args'     => array(
@@ -136,6 +136,15 @@ abstract class Tools
                     'descriptions' => $descriptions['descriptions']
                 )
             );
+
+            if (is_array($data['values'][$attribute->getName()])) {
+                $attributesValues = [
+                    $attributesValues,
+                    $data['values'][$attribute->getName()]
+                ];
+            }
+
+            $data['values'][$attribute->getName()] = $attributesValues;
         }
 
         return $data;

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -138,10 +138,10 @@ abstract class Tools
             );
 
             if (is_array($data['values'][$attribute->getName()])) {
-                $attributesValues = [
+                $attributesValues = array(
                     $attributesValues,
                     $data['values'][$attribute->getName()]
-                ];
+                );
             }
 
             $data['values'][$attribute->getName()] = $attributesValues;


### PR DESCRIPTION
Couple of fixes to bugs I found while using.

1. Multi line function calls didn't work with the go to functionality.
2. If a property and a method is named the same the property would overwrite the method. Now both are suggested.
3. If your class or namespace declarations weren't all lowercase it wouldn't autocomplete.

I found that chained functions `$this->index()->search()` ..etc will go to as well, as long as the function has a `@return`.