### PR TITLE
Bugfixes + property goto

### DIFF
--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -109,7 +109,7 @@ class AbstractGoto
                     @gotoFromWord(editor, @$(selector).text())
                     event.handled = true
             editor.onDidChangeCursorPosition (event) =>
-                return # Temporary
+                # return # Temporary
 
                 if @isHovering == false
                     return

--- a/lib/goto/class-goto.coffee
+++ b/lib/goto/class-goto.coffee
@@ -35,6 +35,7 @@ class GotoClass extends AbstractGoto
 
         @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
         if matches[0] == term || matches.length == 1
+            @jumpWord = /(?:\\)(\w+)$/i.exec(term)[1]
             atom.workspace.open(classMap[matches[0]], {
                 searchAllPanes: true
             })
@@ -46,6 +47,7 @@ class GotoClass extends AbstractGoto
 
             withCurrentNamespace = currentClass.replace(/(\w+)$/, term);
             if matches.indexOf(withCurrentNamespace) != -1
+                @jumpWord = /(?:\\)(\w+)$/i.exec(term)[1]
                 atom.workspace.open(classMap[withCurrentNamespace], {
                     searchAllPanes: true
                 })
@@ -66,9 +68,10 @@ class GotoClass extends AbstractGoto
 
             # if we found a unique match
             if bestMatch and useBestMatch
-              atom.workspace.open(bestMatch, {
+                @jumpWord = /(?:\\)(\w+)$/i.exec(term)[1]
+                atom.workspace.open(bestMatch, {
                   searchAllPanes: true
-              })
+                })
             else
               @selectView.setItems(listViewArray)
               @selectView.show()
@@ -141,3 +144,11 @@ class GotoClass extends AbstractGoto
                 if shouldBreak == true
                     break
             currentIndex += value.length;
+
+    ###*
+     * Gets the regex used when looking for a word within the editor
+     * @param  {string} term Term being search.
+     * @return {regex}       Regex to be used.
+    ###
+    getJumpToRegex: (term) ->
+        return ///^(class|interface|abstract class|trait)\ +#{term}///i

--- a/lib/goto/class-goto.coffee
+++ b/lib/goto/class-goto.coffee
@@ -3,8 +3,8 @@ AbstractGoto = require './abstract-goto'
 module.exports =
 class GotoClass extends AbstractGoto
 
-    hoverEventSelectors: '.meta.inherited-class, .support.namespace, .support.class, .comment-clickable .region'
-    clickEventSelectors: '.meta.inherited-class, .support.namespace, .support.class'
+    hoverEventSelectors: '.entity.inherited-class, .support.namespace, .support.class, .comment-clickable .region'
+    clickEventSelectors: '.entity.inherited-class, .support.namespace, .support.class'
     gotoRegex: /^\\?[A-Z][A-za-z0-9_]*(\\[A-Z][A-Za-z0-9_])*$/
 
     ###*
@@ -42,6 +42,15 @@ class GotoClass extends AbstractGoto
             # if we found a file that end with the exact namespace given, we store it
             bestMatch    = null
             useBestMatch = true
+            currentClass = @parser.getCurrentClass(editor, editor.getCursorBufferPosition())
+
+            withCurrentNamespace = currentClass.replace(/(\w+)$/, term);
+            if matches.indexOf(withCurrentNamespace) != -1
+                atom.workspace.open(classMap[withCurrentNamespace], {
+                    searchAllPanes: true
+                })
+                return
+
 
             for key,value of matches
                 if value.endsWith(term)
@@ -79,6 +88,9 @@ class GotoClass extends AbstractGoto
            @$(selector).prev().hasClass('namespace') && @$(selector).hasClass('class') ||
            @$(selector).next().hasClass('class')
             return @$(selector).parent().children('.namespace, .class:not(.operator):not(.constant)')
+
+        if @$(selector).prev().hasClass('namespace') || @$(selector).next().hasClass('inherited-class')
+            return @$(selector).parent().children('.namespace, .inherited-class')
 
         return selector
 

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -6,7 +6,7 @@ class GotoFunction extends AbstractGoto
 
     hoverEventSelectors: '.function-call'
     clickEventSelectors: '.function-call'
-    gotoRegex: /^(\$\w+)?((->|::)\w+)+/
+    gotoRegex: /^(\$\w+)?((->|::)\w+\()+/
 
     ###*
      * Initialisation of Gotos
@@ -48,7 +48,7 @@ class GotoFunction extends AbstractGoto
 
         currentClass = @parser.getCurrentClass(editor, bufferPosition)
         termParts = term.split(splitter)
-        term = termParts.pop()
+        term = termParts.pop().replace('(', '')
         if currentClass == calledClass && @jumpToFunction(editor, term)
             @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
             return

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -54,6 +54,12 @@ class GotoFunction extends AbstractGoto
             return
 
         methods = proxy.methods(calledClass)
+        if methods.error? and methods.error != ''
+            atom.notifications.addError('Failed to get methods for ' + calledClass, {
+                'detail': methods.error.message
+            })
+            return
+
         if methods.names.indexOf(term) == -1
             return
         value = methods.values[term]

--- a/lib/goto/goto-manager.coffee
+++ b/lib/goto/goto-manager.coffee
@@ -1,5 +1,6 @@
 GotoClass = require './class-goto.coffee'
 GotoFunction = require './function-goto.coffee'
+GotoProperty = require './property-goto.coffee'
 {TextEditor} = require 'atom'
 parser = require '../services/php-file-parser.coffee'
 
@@ -14,6 +15,7 @@ class GotoManager
     init: () ->
         @gotos.push new GotoClass()
         @gotos.push new GotoFunction()
+        @gotos.push new GotoProperty()
         for goto in @gotos
             goto.init(@)
 

--- a/lib/goto/property-goto.coffee
+++ b/lib/goto/property-goto.coffee
@@ -1,0 +1,98 @@
+AbstractGoto = require './abstract-goto'
+{TextEditor} = require 'atom'
+
+module.exports =
+class GotoProperty extends AbstractGoto
+
+    hoverEventSelectors: '.property'
+    clickEventSelectors: '.property'
+    gotoRegex: /^(\$\w+)?((->|::)\w+)+/
+
+    ###*
+     * Initialisation of Gotos
+     * @param  {GotoManager} manager The manager that stores this goto.
+     *                               Used mainly for backtrack registering.
+    ###
+    init: (manager) ->
+        super(manager)
+        @jumpToPropertyOnLoad = ''
+        atom.workspace.onDidChangeActivePaneItem (paneItem) =>
+            if paneItem instanceof TextEditor && @jumpToPropertyOnLoad != ''
+                @jumpToProperty(paneItem, @jumpToPropertyOnLoad)
+                @jumpToPropertyOnLoad = ''
+
+    ###*
+     * Goto the property from the term given.
+     * @param  {TextEditor} editor  TextEditor to search for namespace of term.
+     * @param  {string}     term    Term to search for.
+    ###
+    gotoFromWord: (editor, term) ->
+        proxy = require '../services/php-proxy.coffee'
+        bufferPosition = editor.getCursorBufferPosition()
+        fullCall = @parser.getStackClasses(editor, bufferPosition)
+
+        if fullCall.length == 0 or !term
+          return
+
+        calledClass = ''
+        splitter = '->'
+        if fullCall.length > 1
+            calledClass = @parser.parseElements(editor, bufferPosition, fullCall)
+        else
+            parts = fullCall[0].trim().split('::')
+            splitter = '::'
+            if parts[0] == 'parent'
+                calledClass = @parser.getParentClass(editor)
+            else
+                calledClass = @parser.findUseForClass(editor, parts[0])
+
+        currentClass = @parser.getCurrentClass(editor, bufferPosition)
+        termParts = term.split(splitter)
+        term = termParts.pop()
+        if currentClass == calledClass && @jumpToProperty(editor, term)
+            @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
+            return
+
+        methods = proxy.methods(calledClass)
+        if methods.names.indexOf(term) == -1
+            return
+        value = methods.values[term]
+        parentClass = ''
+        if value instanceof Array
+            for val in value
+                if !val.isMethod
+                    parentClass = val.declaringClass
+                    break
+        else
+            parentClass = value.declaringClass;
+
+        classMap = proxy.autoloadClassMap()
+
+        atom.workspace.open(classMap[parentClass], {
+            searchAllPanes: true
+        })
+        @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
+        @jumpToPropertyOnLoad = term
+
+    ###*
+     * Jumps to the property within the editor
+     * @param  {TextEditor} editor The editor that has the function in.
+     * @param  {string} method     The function to find and then jump to.
+     * @return {boolean}           Whether the finding was successful.
+    ###
+    jumpToProperty: (editor, property) ->
+        bufferPosition = @parser.findBufferPositionOfProperty(editor, property)
+        if bufferPosition == null
+            return false
+
+        # Small delay to wait for when a editor is being created.
+        setTimeout(() ->
+            editor.setCursorBufferPosition(bufferPosition, {
+                autoscroll: false
+            })
+            # Separated these as the autoscroll on setCursorBufferPosition
+            # didn't work as well.
+            editor.scrollToScreenPosition(editor.screenPositionForBufferPosition(bufferPosition), {
+                center: true
+            })
+        , 100)

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -413,7 +413,8 @@ module.exports =
     foundEnd = false
     startBufferPosition = []
     endBufferPosition = []
-    regex = /\(|\s|\)|;|'|,|"|\|/
+    forwardRegex = /-|(?:\()[\w\[\$\(\\]|\s|\)|;|'|,|"|\|/
+    backwardRegex = /\(|\s|\)|;|'|,|"|\|/
     index = -1
     previousText = ''
 
@@ -422,7 +423,7 @@ module.exports =
       startBufferPosition = [position.row, position.column - index - 1]
       range = [[position.row, position.column], [startBufferPosition[0], startBufferPosition[1]]]
       currentText = editor.getTextInBufferRange(range)
-      if regex.test(editor.getTextInBufferRange(range)) || startBufferPosition[1] == -1 || currentText == previousText
+      if backwardRegex.test(editor.getTextInBufferRange(range)) || startBufferPosition[1] == -1 || currentText == previousText
           foundStart = true
       previousText = editor.getTextInBufferRange(range)
       break if foundStart
@@ -432,7 +433,7 @@ module.exports =
       endBufferPosition = [position.row, position.column + index + 1]
       range = [[position.row, position.column], [endBufferPosition[0], endBufferPosition[1]]]
       currentText = editor.getTextInBufferRange(range)
-      if regex.test(currentText) || endBufferPosition[1] == 500 || currentText == previousText
+      if forwardRegex.test(currentText) || endBufferPosition[1] == 500 || currentText == previousText
           foundEnd = true
       previousText = editor.getTextInBufferRange(range)
       break if foundEnd

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -470,51 +470,45 @@ module.exports =
         return @findUseForClass(editor, words[extendsIndex + 1])
 
   ###*
-   * Finds the buffer position of the function name given
+   * Finds the buffer position of the word given
    * @param  {TextEditor} editor TextEditor to search
    * @param  {string}     term   The function name to search for
    * @return {mixed}             Either null or the buffer position of the function.
   ###
-  findBufferPositionOfFunction: (editor, term) ->
-    text = editor.getText()
-    row = 0
-    lines = text.split('\n')
-    for line in lines
-      regex = ///function\ +#{term}(\ +|\()///i
-      if regex.test(line)
-        words = line.split(' ')
-        functionIndex = 0
-        for element in words
-            if element.indexOf(term) != -1
-                break
-            functionIndex++;
-
-        reducedWords = words.slice(0, functionIndex).join(' ')
-        return [row, reducedWords.length + 1]
-      row += 1
-    return null
+  findBufferPositionOfWord: (editor, term, regex, line = null) ->
+    if line != null
+      lineText = editor.lineTextForBufferRow(line)
+      result = @checkLineForWord(lineText, term, regex)
+      if result != null
+        return [line, result]
+    else
+      text = editor.getText()
+      row = 0
+      lines = text.split('\n')
+      for line in lines
+        result = @checkLineForWord(line, term, regex)
+        if result != null
+          return [row, result]
+        row++
+    return null;
 
   ###*
-   * Finds the buffer position of the property name given
-   * @param  {TextEditor} editor TextEditor to search
-   * @param  {string}     term   The function name to search for
-   * @return {mixed}             Either null or the buffer position of the function.
+   * Checks the lineText for the term and regex matches
+   * @param  {string}   lineText The line of text to check.
+   * @param  {string}   term     Term to look for.
+   * @param  {regex}    regex    Regex to run on the line to make sure it's valid
+   * @return {null|int}          Returns null if nothing was found or an
+   *                             int of the column the term is on.
   ###
-  findBufferPositionOfProperty: (editor, term) ->
-    text = editor.getText()
-    row = 0
-    lines = text.split('\n')
-    for line in lines
-      regex = ///(protected|public|private|static)\ +\$#{term}///i
-      if regex.test(line)
-        words = line.split(' ')
-        propertyIndex = 0
-        for element in words
-            if element.indexOf('$' + term) != -1
-                break
-            propertyIndex++;
+  checkLineForWord: (lineText, term, regex) ->
+    if regex.test(lineText)
+      words = lineText.split(' ')
+      propertyIndex = 0
+      for element in words
+        if element.indexOf(term) != -1
+          break
+        propertyIndex++;
 
-        reducedWords = words.slice(0, propertyIndex).join(' ')
-        return [row, reducedWords.length + 1]
-      row += 1
+      reducedWords = words.slice(0, propertyIndex).join(' ')
+      return reducedWords.length + 1
     return null

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -484,3 +484,28 @@ module.exports =
         return [row, reducedWords.length + 1]
       row += 1
     return null
+
+  ###*
+   * Finds the buffer position of the property name given
+   * @param  {TextEditor} editor TextEditor to search
+   * @param  {string}     term   The function name to search for
+   * @return {mixed}             Either null or the buffer position of the function.
+  ###
+  findBufferPositionOfProperty: (editor, term) ->
+    text = editor.getText()
+    row = 0
+    lines = text.split('\n')
+    for line in lines
+      regex = ///(protected|public|private|static)\ +\$#{term}///i
+      if regex.test(line)
+        words = line.split(' ')
+        propertyIndex = 0
+        for element in words
+            if element.indexOf('$' + term) != -1
+                break
+            propertyIndex++;
+
+        reducedWords = words.slice(0, propertyIndex).join(' ')
+        return [row, reducedWords.length + 1]
+      row += 1
+    return null

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -280,6 +280,8 @@ module.exports =
       element = element.replace /^\s+|\s+$/g, ""
       if element[0] == '{' or element[0] == '(' or element[0] == '['
         element = element.substring(1)
+      else if element.indexOf('return ') == 0
+        element = element.substring('return '.length)
 
       elements[key] = element
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -226,6 +226,7 @@ module.exports =
     lineIdx = 0
     parenthesisOpened = 0
     parenthesisClosed = 0
+    squiggleBracketOpened = false
     idx = 0
     end = false
 
@@ -241,14 +242,20 @@ module.exports =
           parenthesisOpened += 1
         else if text[len - idx] == ")"
           parenthesisClosed += 1
-        else if text[len - idx] == "{" # If curly brace, we failed.
+        else if text[len - idx] == "}"
+          # Not going to do the semi,equals,{ check (else if below) as we are probably in a callback.
+          squiggleBracketOpened = true
+        else if text[len - idx] == "{" and squiggleBracketOpened
+          squiggleBracketOpened = false
+        # Checking we haven't hit a semi or equals. As parent calls won't have a $ to end on.
+        else if (text[len - (idx + 1)] == ";" or text[len - (idx + 1)] == "=" or text[len - (idx + 1)] == "{") and !squiggleBracketOpened
           end = true
         if text[len - idx] == "$" and parenthesisClosed == parenthesisOpened
           end = true
 
         idx += 1
 
-    text = text.substr(text.length - idx + 1, text.length)
+    text = text.substr(text.length - idx + 1, text.length).trim()
 
     return @parseStackClass(text)
 

--- a/php/providers/AutocompleteProvider.php
+++ b/php/providers/AutocompleteProvider.php
@@ -41,7 +41,7 @@ class AutocompleteProvider extends Tools implements ProviderInterface
         }
 
         $returnValue = $values['args']['return'];
-        if ($returnValue == '$this' || $returnValue == 'self') {
+        if ($returnValue == '$this' || $returnValue == 'self' || $returnValue == 'static') {
             return $data;
         } elseif (ucfirst($returnValue) === $returnValue) {
             $parser = new FileParser($classMap[$class]);

--- a/php/providers/AutocompleteProvider.php
+++ b/php/providers/AutocompleteProvider.php
@@ -12,7 +12,7 @@ class AutocompleteProvider extends Tools implements ProviderInterface
         $class = $args[0];
         $name  = $args[1];
         $isMethod = false;
-        if (strpos($class, '\\') == 0) {
+        if (strpos($class, '\\') === 0) {
             $class = substr($class, 1);
         }
         if (strpos($name, '()') > -1) {

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -113,7 +113,8 @@ abstract class Tools
                 'isPublic'       => $method->isPublic(),
                 'isProtected'    => $method->isProtected(),
                 'args'           => $args,
-                'declaringClass' => $method->getDeclaringClass()->name
+                'declaringClass' => $method->getDeclaringClass()->name,
+                'startLine'      => $method->getStartLine()
             );
         }
 

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -131,6 +131,7 @@ abstract class Tools
             $attributesValues = array(
                 'isMethod' => false,
                 'isPublic' => $attribute->isPublic(),
+                'declaringClass' => $attribute->class,
                 'args'     => array(
                     'return' => !empty($return) ? $return['var'] : '',
                     'descriptions' => $descriptions['descriptions']


### PR DESCRIPTION
##### Features
* Added property goto. Works very similar to how functions works (almost the exact same code)
* Added a notification if the function goto isn't able to jump because proxy.methods returns an error.
 * Found this when trying to jump to an Eloquent function in Laravel.

##### Bugfixes (I hope)
* Fixed if the goto class is in the same namespace as the currently opened class
* Fixed the namespace and class selectors for alt-click not always working.
* Re-enabled the class goto. (From testing I couldn't replicate any problems)
* Fixed getStackClasses not working with things like 
```
$test = parent::foo()
                ---
```
```
$test->foo(function($test) {
       return $test;
})->filter()
    ------
```

* Did some updates to findFullWord function as I needed to define between a property and a function using `(`
* Fixed if the phpdoc has a return of static it not return the methods of itself.
 * Found this in Laravel's Collection as the phpdoc of the funciton has `@return static`

##### Ideas (I realise they aren't related to the PR but I didn't want to raise 2 issues for this)
I'm just suggesting these as I don't want to program anything you don't want in your package. 

* Refactor rename of property, function, class name.
 * So when you perform some action (keyboard shortcut, right click...etc) it will bring up a panel that allows you to rename a variable, property...etc. It will then update all references to the new name. [Youtube example](https://www.youtube.com/watch?v=iNJNdm5azdo)
* Have a repository where we can test this package on. It then means people can PR their code into this  test repository and we/you can properly debug it and find out why something isn't working.
 * A bit like what @hotoiledgoblinsack did when trying to explain a bug he found. [Link](https://github.com/Peekmo/atom-autocomplete-php/issues/52#issuecomment-128775877)