### PR TITLE
Add tooltips with descriptions on mouse hover.

### DIFF
--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -26,6 +26,8 @@ class AbstractGoto
         @$ = require 'jquery'
         @parser = require '../services/php-file-parser'
         @fuzzaldrin = require 'fuzzaldrin'
+        {CompositeDisposable} = require 'atom'
+        @subscriptions = new CompositeDisposable
         @manager = manager
         atom.workspace.observeTextEditors (editor) =>
             @registerMarkers editor
@@ -85,6 +87,15 @@ class AbstractGoto
 
 
     ###*
+     * Retrieves a tooltip for the word given.
+     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
+     * @param  {string}     term           Term to search for.
+     * @param  {Point}      bufferPosition The cursor location the term is at.
+    ###
+    getTooltipForWord: (editor, term, bufferPosition) ->
+
+
+    ###*
      * Registers the mouse events for alt-click.
      * @param  {TextEditor} editor  TextEditor to register events to.
     ###
@@ -94,11 +105,29 @@ class AbstractGoto
             scrollViewElement = @$(textEditorElement.shadowRoot).find('.scroll-view')
 
             @subAtom.add scrollViewElement, 'mousemove', @hoverEventSelectors, (event) =>
-                if event.altKey == false
-                    return
                 selector = @getSelector(event)
                 if selector == null
                     return
+
+                # Try to show a tooltip containing the documentation of the item.
+                if not @showingDocumentationTooltip
+                    cursorPosition = atom.views.getView(editor).component.screenPositionForMouseEvent(event)
+
+                    tooltipText = @getTooltipForWord(editor, @$(selector).text(), cursorPosition)
+
+                    @subscriptions.add atom.tooltips.add(event.target, {
+                        title: tooltipText
+                        html: true
+                        placement: 'bottom'
+                        delay:
+                            show: 500
+                    })
+
+                    @showingDocumentationTooltip = true
+
+                if event.altKey == false
+                    return
+
                 @$(selector).css('border-bottom', '1px solid ' + @$(selector).css('color'))
                 @$(selector).css('cursor', 'pointer')
                 @isHovering = true
@@ -106,6 +135,10 @@ class AbstractGoto
                 selector = @getSelector(event)
                 if selector == null
                     return
+
+                @subscriptions.dispose();
+                @showingDocumentationTooltip = false
+
                 @$(selector).css('border-bottom', '')
                 @$(selector).css('cursor', '')
                 @isHovering = false

--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -193,6 +193,36 @@ class AbstractGoto
     getJumpToRegex: (term) ->
 
     ###*
+     * Retrieves the called class and the splitter used.
+     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
+     * @param  {string}     term           Term to search for.
+     * @param  {Point}      bufferPosition The cursor location the term is at.
+    ###
+    getCalledClassInfo: (editor, term, bufferPosition) ->
+        proxy = require '../services/php-proxy.coffee'
+        fullCall = @parser.getStackClasses(editor, bufferPosition)
+
+        if fullCall.length == 0 or !term
+          return
+
+        calledClass = ''
+        splitter = '->'
+        if fullCall.length > 1
+            calledClass = @parser.parseElements(editor, bufferPosition, fullCall)
+        else
+            parts = fullCall[0].trim().split('::')
+            splitter = '::'
+            if parts[0] == 'parent'
+                calledClass = @parser.getParentClass(editor)
+            else
+                calledClass = @parser.findUseForClass(editor, parts[0])
+
+        return {
+            calledClass : calledClass,
+            splitter    : splitter
+        }
+
+    ###*
      * Jumps to a word within the editor
      * @param  {TextEditor} editor The editor that has the function in.
      * @param  {string} word       The word to find and then jump to.

--- a/lib/goto/class-goto.coffee
+++ b/lib/goto/class-goto.coffee
@@ -81,6 +81,15 @@ class GotoClass extends AbstractGoto
               @selectView.show()
 
     ###*
+     * Retrieves a tooltip for the word given.
+     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
+     * @param  {string}     term           Term to search for.
+     * @param  {Point}      bufferPosition The cursor location the term is at.
+    ###
+    getTooltipForWord: (editor, term, bufferPosition) ->
+        # TODO: Not implemented yet (as summaries from class docblocks are not extracted).
+
+    ###*
      * Gets the correct selector when a class or namespace is clicked.
      * @param  {jQuery.Event}  event  A jQuery event.
      * @return {object|null}          A selector to be used with jQuery.

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -30,6 +30,9 @@ class GotoFunction extends AbstractGoto
 
         value = @getMethodForTerm(editor, term, bufferPosition, calledClassInfo)
 
+        if not value
+            return
+
         parentClass = value.declaringClass
 
         proxy = require '../services/php-proxy.coffee'

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -51,6 +51,9 @@ class GotoFunction extends AbstractGoto
     getTooltipForWord: (editor, term, bufferPosition) ->
         value = @getMethodForTerm(editor, term, bufferPosition)
 
+        if not value
+            return
+
         # Create a useful description to show in the tooltip.
         returnType = if value.args.return then value.args.return else 'void'
 

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -80,36 +80,6 @@ class GotoFunction extends AbstractGoto
         return description
 
     ###*
-     * Retrieves the called class and the splitter used.
-     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
-     * @param  {string}     term           Term to search for.
-     * @param  {Point}      bufferPosition The cursor location the term is at.
-    ###
-    getCalledClassInfo: (editor, term, bufferPosition) ->
-        proxy = require '../services/php-proxy.coffee'
-        fullCall = @parser.getStackClasses(editor, bufferPosition)
-
-        if fullCall.length == 0 or !term
-          return
-
-        calledClass = ''
-        splitter = '->'
-        if fullCall.length > 1
-            calledClass = @parser.parseElements(editor, bufferPosition, fullCall)
-        else
-            parts = fullCall[0].trim().split('::')
-            splitter = '::'
-            if parts[0] == 'parent'
-                calledClass = @parser.getParentClass(editor)
-            else
-                calledClass = @parser.findUseForClass(editor, parts[0])
-
-        return {
-            calledClass : calledClass,
-            splitter    : splitter
-        }
-
-    ###*
      * Retrieves information about the method described by the specified term.
      * @param  {TextEditor} editor          TextEditor to search for namespace of term.
      * @param  {string}     term            Term to search for.

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -14,8 +14,79 @@ class GotoFunction extends AbstractGoto
      * @param  {string}     term    Term to search for.
     ###
     gotoFromWord: (editor, term) ->
-        proxy = require '../services/php-proxy.coffee'
         bufferPosition = editor.getCursorBufferPosition()
+
+        calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+        calledClass = calledClassInfo.calledClass
+        splitter = calledClassInfo.splitter
+
+        currentClass = @parser.getCurrentClass(editor, bufferPosition)
+
+        termParts = term.split(splitter)
+        term = termParts.pop().replace('(', '')
+        if currentClass == calledClass && @jumpTo(editor, term)
+            @manager.addBackTrack(editor.getPath(), bufferPosition)
+            return
+
+        value = @getMethodForTerm(editor, term, bufferPosition, calledClassInfo)
+
+        parentClass = value.declaringClass
+
+        proxy = require '../services/php-proxy.coffee'
+        classMap = proxy.autoloadClassMap()
+
+        atom.workspace.open(classMap[parentClass], {
+            searchAllPanes: true
+        })
+        @manager.addBackTrack(editor.getPath(), bufferPosition)
+        @jumpWord = term
+        @jumpLine = value.startLine - 1
+
+    ###*
+     * Retrieves a tooltip for the word given.
+     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
+     * @param  {string}     term           Term to search for.
+     * @param  {Point}      bufferPosition The cursor location the term is at.
+    ###
+    getTooltipForWord: (editor, term, bufferPosition) ->
+        value = @getMethodForTerm(editor, term, bufferPosition)
+
+        # Create a useful description to show in the tooltip.
+        returnType = if value.args.return then value.args.return else 'void'
+
+        description = returnType + ' ' + term + '('
+
+        if value.args.parameters.length > 0
+            description += value.args.parameters.join(', ');
+
+        if value.args.optionals.length > 0
+            description += '['
+
+            if value.args.parameters.length > 0
+                description += ', '
+
+            description += value.args.optionals.join(', ')
+            description += ']'
+
+        description += ')'
+        description += "<br/><br/>"
+
+        if value.args.descriptions.short
+            description += value.args.descriptions.short
+
+        else
+            description += '(No documentation available)'
+
+        return description
+
+    ###*
+     * Retrieves the called class and the splitter used.
+     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
+     * @param  {string}     term           Term to search for.
+     * @param  {Point}      bufferPosition The cursor location the term is at.
+    ###
+    getCalledClassInfo: (editor, term, bufferPosition) ->
+        proxy = require '../services/php-proxy.coffee'
         fullCall = @parser.getStackClasses(editor, bufferPosition)
 
         if fullCall.length == 0 or !term
@@ -33,13 +104,29 @@ class GotoFunction extends AbstractGoto
             else
                 calledClass = @parser.findUseForClass(editor, parts[0])
 
-        currentClass = @parser.getCurrentClass(editor, bufferPosition)
+        return {
+            calledClass : calledClass,
+            splitter    : splitter
+        }
+
+    ###*
+     * Retrieves information about the method described by the specified term.
+     * @param  {TextEditor} editor          TextEditor to search for namespace of term.
+     * @param  {string}     term            Term to search for.
+     * @param  {Point}      bufferPosition  The cursor location the term is at.
+     * @param  {Object}     calledClassInfo Information about the called class (optional).
+    ###
+    getMethodForTerm: (editor, term, bufferPosition, calledClassInfo) ->
+        if not calledClassInfo
+            calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+
+        calledClass = calledClassInfo.calledClass
+        splitter = calledClassInfo.splitter
+
         termParts = term.split(splitter)
         term = termParts.pop().replace('(', '')
-        if currentClass == calledClass && @jumpTo(editor, term)
-            @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
-            return
 
+        proxy = require '../services/php-proxy.coffee'
         methods = proxy.methods(calledClass)
         if methods.error? and methods.error != ''
             atom.notifications.addError('Failed to get methods for ' + calledClass, {
@@ -50,24 +137,15 @@ class GotoFunction extends AbstractGoto
         if methods.names.indexOf(term) == -1
             return
         value = methods.values[term]
-        parentClass = ''
+
+        # If there are multiple matches, just select the first method.
         if value instanceof Array
             for val in value
                 if val.isMethod
-                    parentClass = val.declaringClass
                     value = val
                     break
-        else
-            parentClass = value.declaringClass;
 
-        classMap = proxy.autoloadClassMap()
-
-        atom.workspace.open(classMap[parentClass], {
-            searchAllPanes: true
-        })
-        @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
-        @jumpWord = term
-        @jumpLine = value.startLine - 1
+        return value
 
     ###*
      * Gets the regex used when looking for a word within the editor

--- a/lib/goto/property-goto.coffee
+++ b/lib/goto/property-goto.coffee
@@ -53,8 +53,18 @@ class GotoProperty extends AbstractGoto
         # Create a useful description to show in the tooltip.
         returnType = if value.args.return then value.args.return else 'mixed'
 
-        description = (if value.isPublic then 'public' else ' protected|private') + ' ' + returnType + ' $' + term;
+        description = ''
 
+        if value.isPublic
+            description += 'public'
+
+        else if value.isProtected
+            description += 'protected'
+
+        else
+            description += 'private'
+
+        description += ' ' + returnType + ' $' + term;
         description += "<br/><br/>"
 
         if value.args.descriptions.short

--- a/lib/goto/property-goto.coffee
+++ b/lib/goto/property-goto.coffee
@@ -50,6 +50,9 @@ class GotoProperty extends AbstractGoto
     getTooltipForWord: (editor, term, bufferPosition) ->
         value = @getPropertyForTerm(editor, term, bufferPosition)
 
+        if not value
+            return
+
         # Create a useful description to show in the tooltip.
         returnType = if value.args.return then value.args.return else 'mixed'
 

--- a/lib/goto/property-goto.coffee
+++ b/lib/goto/property-goto.coffee
@@ -66,36 +66,6 @@ class GotoProperty extends AbstractGoto
         return description
 
     ###*
-     * Retrieves the called class and the splitter used.
-     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
-     * @param  {string}     term           Term to search for.
-     * @param  {Point}      bufferPosition The cursor location the term is at.
-    ###
-    getCalledClassInfo: (editor, term, bufferPosition) ->
-        proxy = require '../services/php-proxy.coffee'
-        fullCall = @parser.getStackClasses(editor, bufferPosition)
-
-        if fullCall.length == 0 or !term
-          return
-
-        calledClass = ''
-        splitter = '->'
-        if fullCall.length > 1
-            calledClass = @parser.parseElements(editor, bufferPosition, fullCall)
-        else
-            parts = fullCall[0].trim().split('::')
-            splitter = '::'
-            if parts[0] == 'parent'
-                calledClass = @parser.getParentClass(editor)
-            else
-                calledClass = @parser.findUseForClass(editor, parts[0])
-
-        return {
-            calledClass : calledClass,
-            splitter    : splitter
-        }
-
-    ###*
      * Retrieves information about the property described by the specified term.
      * @param  {TextEditor} editor          TextEditor to search for namespace of term.
      * @param  {string}     term            Term to search for.

--- a/lib/goto/property-goto.coffee
+++ b/lib/goto/property-goto.coffee
@@ -14,8 +14,65 @@ class GotoProperty extends AbstractGoto
      * @param  {string}     term    Term to search for.
     ###
     gotoFromWord: (editor, term) ->
-        proxy = require '../services/php-proxy.coffee'
         bufferPosition = editor.getCursorBufferPosition()
+
+        calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+        calledClass = calledClassInfo.calledClass
+        splitter = calledClassInfo.splitter
+
+        currentClass = @parser.getCurrentClass(editor, bufferPosition)
+
+        termParts = term.split(splitter)
+        term = termParts.pop()
+        if currentClass == calledClass && @jumpTo(editor, term)
+            @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
+            return
+
+        value = @getPropertyForTerm(editor, term, bufferPosition, calledClassInfo)
+
+        parentClass = value.declaringClass
+
+        proxy = require '../services/php-proxy.coffee'
+        classMap = proxy.autoloadClassMap()
+
+        atom.workspace.open(classMap[parentClass], {
+            searchAllPanes: true
+        })
+        @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
+        @jumpWord = term
+
+    ###*
+     * Retrieves a tooltip for the word given.
+     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
+     * @param  {string}     term           Term to search for.
+     * @param  {Point}      bufferPosition The cursor location the term is at.
+    ###
+    getTooltipForWord: (editor, term, bufferPosition) ->
+        value = @getPropertyForTerm(editor, term, bufferPosition)
+
+        # Create a useful description to show in the tooltip.
+        returnType = if value.args.return then value.args.return else 'mixed'
+
+        description = (if value.isPublic then 'public' else ' protected|private') + ' ' + returnType + ' $' + term;
+
+        description += "<br/><br/>"
+
+        if value.args.descriptions.short
+            description += value.args.descriptions.short
+
+        else
+            description += '(No documentation available)'
+
+        return description
+
+    ###*
+     * Retrieves the called class and the splitter used.
+     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
+     * @param  {string}     term           Term to search for.
+     * @param  {Point}      bufferPosition The cursor location the term is at.
+    ###
+    getCalledClassInfo: (editor, term, bufferPosition) ->
+        proxy = require '../services/php-proxy.coffee'
         fullCall = @parser.getStackClasses(editor, bufferPosition)
 
         if fullCall.length == 0 or !term
@@ -33,37 +90,40 @@ class GotoProperty extends AbstractGoto
             else
                 calledClass = @parser.findUseForClass(editor, parts[0])
 
-        currentClass = @parser.getCurrentClass(editor, bufferPosition)
-        termParts = term.split(splitter)
-        term = termParts.pop()
-        if currentClass == calledClass && @jumpTo(editor, term)
-            @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
+        return {
+            calledClass : calledClass,
+            splitter    : splitter
+        }
+
+    ###*
+     * Retrieves information about the property described by the specified term.
+     * @param  {TextEditor} editor          TextEditor to search for namespace of term.
+     * @param  {string}     term            Term to search for.
+     * @param  {Point}      bufferPosition  The cursor location the term is at.
+     * @param  {Object}     calledClassInfo Information about the called class (optional).
+    ###
+    getPropertyForTerm: (editor, term, bufferPosition, calledClassInfo) ->
+        if not calledClassInfo
+            calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+
+        calledClass = calledClassInfo.calledClass
+
+        proxy = require '../services/php-proxy.coffee'
+        methodsAndProperties = proxy.methods(calledClass)
+        if not methodsAndProperties.names?
             return
 
-        methods = proxy.methods(calledClass)
-        if not methods.names?
+        if methodsAndProperties.names.indexOf(term) == -1
             return
+        value = methodsAndProperties.values[term]
 
-        if methods.names.indexOf(term) == -1
-            return
-        value = methods.values[term]
-        parentClass = ''
         if value instanceof Array
             for val in value
                 if !val.isMethod
-                    parentClass = val.declaringClass
                     value = val
                     break
-        else
-            parentClass = value.declaringClass;
 
-        classMap = proxy.autoloadClassMap()
-
-        atom.workspace.open(classMap[parentClass], {
-            searchAllPanes: true
-        })
-        @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
-        @jumpWord = term
+        return value
 
     ###*
      * Gets the regex used when looking for a word within the editor

--- a/lib/goto/property-goto.coffee
+++ b/lib/goto/property-goto.coffee
@@ -30,6 +30,9 @@ class GotoProperty extends AbstractGoto
 
         value = @getPropertyForTerm(editor, term, bufferPosition, calledClassInfo)
 
+        if not value
+            return
+
         parentClass = value.declaringClass
 
         proxy = require '../services/php-proxy.coffee'

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -136,6 +136,7 @@ abstract class Tools
             $attributesValues = array(
                 'isMethod' => false,
                 'isPublic' => $attribute->isPublic(),
+                'isProtected'    => $attribute->isProtected(),
                 'declaringClass' => $attribute->class,
                 'args'     => array(
                     'return' => !empty($return) ? $return['var'] : '',


### PR DESCRIPTION
Hello

I decided to start tinkering a bit with the code myself, annoying you with pull requests as well as bug reports ;-). This adds support for mouse tooltips when hovering over known methods and properties.

Note the following things:
  * The current timeout for the tooltip is 500ms, which seems reasonable to avoid annoying the user.
  * Tooltips on class names are not implemented as I'm not sure docblocks from classes are even extracted on the PHP side at the moment. I've added a TODO in class-goto for this.
  * Very strangely, I've noticed that sometimes it takes a few mousemove and mouseout events for the tooltip to start showing for the first time, even though the code is actually properly executed. After the initial show, it works as intended for that specific `HTMLElement`.

@CWDN  I've also noticed `mousemove` being used in `abstract-goto.coffee`, causing the method to be invoked on every mouse move, is there a reason `mouseover` isn't used instead?

I have very little experience with CoffeeScript, so feedback is also appreciated in that regard.

Thanks in advance