### PR TITLE
Let method and property docblocks inherit from parent classes and refactor.

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -8,6 +8,8 @@ module.exports =
    * Get plugin configuration
   ###
   getConfig: () ->
+    # See also https://secure.php.net/urlhowto.php .
+    @config['php_function_documentation_base_url'] = 'https://secure.php.net/function.';
     @config['composer'] = atom.config.get('atom-autocomplete-php.binComposer')
     @config['php'] = atom.config.get('atom-autocomplete-php.binPhp')
     @config['autoload'] = atom.config.get('atom-autocomplete-php.autoloadPaths')

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -76,15 +76,21 @@ class GotoFunction extends AbstractGoto
 
         description += ')'
 
-        # Show a description of the method.
+        # Show the summary (short description) of the method.
         description += "<br/><br/>"
-        description += (if value.args.descriptions.short then value.args.descriptions.short else '(No documentation available)');
+        description += '<span>' + (if value.args.descriptions.short then value.args.descriptions.short else '(No documentation available)') + '</span>';
+
+        # Show the (long) description of the method.
+        if value.args.descriptions.long?.length > 0
+            description += "<br/><br/>"
+            description += "Description:<br/>"
+            description += "<span style='margin-left: 1em;'>" + value.args.descriptions.long + "</span>"
 
         # Show an overview of the exceptions the method can throw.
         throwsDescription = "";
 
         for exceptionType,thrownWhenDescription of value.args.throws
-            throwsDescription += "<div style='margin-left: 1em;'>• " + "<strong>" + exceptionType + "</strong>" + ' ' + thrownWhenDescription + "</div>"
+            throwsDescription += "<span style='margin-left: 1em;'>• " + "<strong>" + exceptionType + "</strong>" + ' ' + thrownWhenDescription + "</span><br/>"
 
         if throwsDescription.length > 0
             description += "<br/><br/>"

--- a/lib/providers/autocomplete-provider.coffee
+++ b/lib/providers/autocomplete-provider.coffee
@@ -65,7 +65,7 @@ class AutocompleteProvider extends AbstractProvider
    * @param {array} suggestions  An array of suggestions for the current word.
   ###
   addSuggestion: (word, element, suggestions) ->
-    returnValues = element.args.return.split('\\')
+    returnValues = if element.args.return then element.args.return.split('\\') else []
 
     # Methods
     if element.isMethod

--- a/lib/providers/function-provider.coffee
+++ b/lib/providers/function-provider.coffee
@@ -45,6 +45,7 @@ class FunctionProvider extends AbstractProvider
         suggestions.push
           text: word,
           type: 'function',
+          className: if element.args.deprecated then 'php-atom-autocomplete-strike' else ''
           snippet: @getFunctionSnippet(word, element.args),
           replacementPrefix: prefix
 

--- a/lib/providers/function-provider.coffee
+++ b/lib/providers/function-provider.coffee
@@ -5,6 +5,8 @@ proxy = require "../services/php-proxy.coffee"
 parser = require "../services/php-file-parser.coffee"
 AbstractProvider = require "./abstract-provider"
 
+config = require "../config.coffee"
+
 module.exports =
 # Autocomplete for internal PHP functions
 class FunctionProvider extends AbstractProvider
@@ -45,6 +47,8 @@ class FunctionProvider extends AbstractProvider
         suggestions.push
           text: word,
           type: 'function',
+          description: 'Built-in PHP function.' # Needed or the 'More' button won't show up.
+          descriptionMoreURL: config.config.php_function_documentation_base_url + word
           className: if element.args.deprecated then 'php-atom-autocomplete-strike' else ''
           snippet: @getFunctionSnippet(word, element.args),
           replacementPrefix: prefix

--- a/php/providers/StaticsProvider.php
+++ b/php/providers/StaticsProvider.php
@@ -31,7 +31,7 @@ class StaticsProvider extends Tools implements ProviderInterface
         foreach ($methods as $method) {
             $statics['names'][] = $method->getName();
 
-            $args = $this->getMethodArguments($method, $class); 
+            $args = $this->getMethodArguments($method); 
 
             $statics['values'][$method->getName()] = array(
                 array(

--- a/php/services/DocParser.php
+++ b/php/services/DocParser.php
@@ -11,18 +11,23 @@ class DocParser
     const DEPRECATED = '@deprecated';
     const THROWS = '@throws';
     const DESCRIPTION = 'description';
+    const INHERITDOC = '{@inheritDoc}';
 
     /**
      * Get data for the given class
-     * @param  string $className Full class namespace
-     * @param  string $type      Type searched (method, property)
-     * @param  string $name      Name of the method or property
-     * @param  array  $filters   Fields to get
+     * @param  string|null $className Full class namespace, required for methods and properties
+     * @param  string      $type      Type searched (method, property)
+     * @param  string      $name      Name of the method or property
+     * @param  array       $filters   Fields to get
      * @return array
      */
     public function get($className, $type, $name, $filters)
     {
         switch($type) {
+            case 'function':
+                $reflection = new ReflectionFunction($name);
+                break;
+
             case 'method':
                 $reflection = new ReflectionMethod($className, $name);
                 break;
@@ -56,15 +61,11 @@ class DocParser
             switch ($filter) {
                 case self::VAR_TYPE:
                     $var = $this->parseVar($escapedComment);
-                    if ($var) {
-                        $result['var'] = $var;
-                    }
+                    $result['var'] = $var ?: null;
                     break;
                 case self::RETURN_VALUE:
                     $return = $this->parseVar($escapedComment, self::RETURN_VALUE);
-                    if ($return) {
-                        $result['return'] = $return;
-                    }
+                    $result['return'] = $return ?: null;
                     break;
                 case self::PARAM_TYPE:
                     $res = $escapedComment;

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -138,7 +138,7 @@ abstract class Tools
             'throws'       => $docParseResult['throws'],
             'return'       => $docParseResult['return'],
             'descriptions' => $docParseResult['descriptions'],
-            'deprecated'   => $docParseResult['deprecated']
+            'deprecated'   => $function->isDeprecated() || $docParseResult['deprecated']
         );
     }
 


### PR DESCRIPTION
Hello

This further improves on your implementation of #34 by using the docblock from the method or property in parent classes if available, which is mostly useful for overrides so you don't have to copy the docblock over to get the description.