### PR TITLE
Prune comments in parseStackClass before processing (fixes issue with fluent methods and alt-click).

### DIFF
--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -280,8 +280,6 @@ module.exports =
     text = text.replace regx, (match) =>
         return ''
 
-    debugger
-
     # Get the full text
     return [] if not text
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -270,6 +270,18 @@ module.exports =
     text = text.replace regx, (match) =>
         return '()'
 
+    # Remove singe line comments
+    regx = /\/\/.*\n/g
+    text = text.replace regx, (match) =>
+        return ''
+
+    # Remove multi line comments
+    regx = /\/\*[^(\*\/)]*\*\//g
+    text = text.replace regx, (match) =>
+        return ''
+
+    debugger
+
     # Get the full text
     return [] if not text
 


### PR DESCRIPTION
Hello

This fixes an issue where `parseStackClass` did not prune comments before attempting to process the text. See also [1] for an example where you couldn't alt-click on the methods because these lines were not filtered out.

[1] https://github.com/hotoiledgoblinsack/php-autocomplete-test/blob/cae052ad03b39b912ed4788cb795321349f62dd7/src/TestNamespace/SomeClass.php#L283