### PR TITLE
Fetch thrown exceptions for methods and show them in the tooltip.

### DIFF
--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -116,7 +116,7 @@ class AbstractGoto
                     tooltipText = @getTooltipForWord(editor, @$(selector).text(), cursorPosition)
 
                     @subscriptions.add atom.tooltips.add(event.target, {
-                        title: tooltipText
+                        title: '<div style="text-align: left;">' + tooltipText + '</div>'
                         html: true
                         placement: 'bottom'
                         delay:

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -60,7 +60,7 @@ class GotoFunction extends AbstractGoto
         # Show the method's signature.
         returnType = if value.args.return then value.args.return else 'void'
 
-        description = returnType + ' ' + term + '('
+        description = returnType + ' <strong>' + term + '</strong>' + '('
 
         if value.args.parameters.length > 0
             description += value.args.parameters.join(', ');
@@ -78,23 +78,18 @@ class GotoFunction extends AbstractGoto
 
         # Show a description of the method.
         description += "<br/><br/>"
-
-        if value.args.descriptions.short
-            description += value.args.descriptions.short
-
-        else
-            description += '(No documentation available)'
+        description += (if value.args.descriptions.short then value.args.descriptions.short else '(No documentation available)');
 
         # Show an overview of the exceptions the method can throw.
         throwsDescription = "";
 
         for exceptionType,thrownWhenDescription of value.args.throws
-            throwsDescription += "<li>" + "<strong>" + exceptionType + ' ' + thrownWhenDescription + "</strong>" + "</li>"
+            throwsDescription += "<div style='margin-left: 1em;'>• " + "<strong>" + exceptionType + "</strong>" + ' ' + thrownWhenDescription + "</div>"
 
         if throwsDescription.length > 0
             description += "<br/><br/>"
-            description += "Throws:"
-            description += "<ul>" + throwsDescription + "</ul>"
+            description += "Throws:<br/>"
+            description += throwsDescription
 
         return description
 

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -57,7 +57,7 @@ class GotoFunction extends AbstractGoto
         if not value
             return
 
-        # Create a useful description to show in the tooltip.
+        # Show the method's signature.
         returnType = if value.args.return then value.args.return else 'void'
 
         description = returnType + ' ' + term + '('
@@ -75,6 +75,8 @@ class GotoFunction extends AbstractGoto
             description += ']'
 
         description += ')'
+
+        # Show a description of the method.
         description += "<br/><br/>"
 
         if value.args.descriptions.short
@@ -82,6 +84,17 @@ class GotoFunction extends AbstractGoto
 
         else
             description += '(No documentation available)'
+
+        # Show an overview of the exceptions the method can throw.
+        throwsDescription = "";
+
+        for exceptionType,thrownWhenDescription of value.args.throws
+            throwsDescription += "<li>" + "<strong>" + exceptionType + ' ' + thrownWhenDescription + "</strong>" + "</li>"
+
+        if throwsDescription.length > 0
+            description += "<br/><br/>"
+            description += "Throws:"
+            description += "<ul>" + throwsDescription + "</ul>"
 
         return description
 
@@ -97,7 +110,7 @@ class GotoFunction extends AbstractGoto
             calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
 
         if not calledClassInfo
-            return    
+            return
 
         calledClass = calledClassInfo.calledClass
         splitter = calledClassInfo.splitter

--- a/lib/goto/property-goto.coffee
+++ b/lib/goto/property-goto.coffee
@@ -70,7 +70,7 @@ class GotoProperty extends AbstractGoto
         else
             description += 'private'
 
-        description += ' ' + returnType + ' $' + term;
+        description += ' ' + returnType + '<strong>' + ' $' + term + '</strong>';
         description += "<br/><br/>"
 
         if value.args.descriptions.short

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -72,15 +72,17 @@ abstract class Tools
             $parser = new DocParser();
             $return = $parser->get($className, 'method', $method->getName(), array(DocParser::RETURN_VALUE));
             $descriptions = $parser->get($className, 'method', $method->getName(), array(DocParser::DESCRIPTION));
+            $throws = $parser->get($className, 'method', $method->getName(), array(DocParser::THROWS));
             $deprecated = $parser->get($className, 'method', $method->getName(), array(DocParser::DEPRECATED));
         }
 
         return array(
-            'parameters' => $parameters,
-            'optionals' => $optionals,
-            'return'    => ($className && !empty($return)) ? $return['return'] : '',
+            'parameters'   => $parameters,
+            'optionals'    => $optionals,
+            'throws'       => ($className && $throws) ? $throws['throws'] : array(),
+            'return'       => ($className && !empty($return)) ? $return['return'] : '',
             'descriptions' => ($className && $descriptions) ? $descriptions['descriptions'] : array(),
-            'deprecated' => $deprecated['deprecated']
+            'deprecated'   => $deprecated['deprecated']
         );
     }
 


### PR DESCRIPTION
Hello

This improvement fetches the thrown (@throws) exceptions listed in the docblock and displays them in the tooltip, along with a description of when they are thrown (if it is present in the docblock).

This also improves the formatting of the tooltip a bit, ensuring it is always left-aligned rather than centered, bolding the method/property name, etc.