### PR TITLE
Test the configuration before going through with initialization.

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -40,6 +40,34 @@ module.exports =
     fs.writeFileSync(@config.packagePath + '/php/tmp.php', text)
 
   ###*
+   * Tests the user's PHP and Composer configuration.
+   * @return {bool}
+  ###
+  testConfig: () ->
+    @getConfig()
+
+    exec = require "child_process"
+    testResult = exec.spawnSync(@config.php, ["-v"])
+
+    errorTitle = 'atom-autocomplete-php - Incorrect setup!'
+    errorMessage = 'Either PHP or Composer is not correctly set up and as a result PHP autocompletion will not work. ' +
+      'Please visit the settings screen to correct this error. If you are not specifying an absolute path for PHP or ' +
+      'Composer, make sure they are in your PATH.'
+
+    if testResult.status = null or testResult.status != 0
+      atom.notifications.addError(errorTitle, {'detail': errorMessage})
+      return false
+
+    # Test Composer.
+    testResult = exec.spawnSync(@config.composer, ["--version"])
+
+    if testResult.status = null or testResult.status != 0
+      atom.notifications.addError(errorTitle, {'detail': errorMessage})
+      return false
+
+    return true
+
+  ###*
    * Init function called on package activation
    * Register config events and write the first config
   ###

--- a/lib/peekmo-php-atom-autocomplete.coffee
+++ b/lib/peekmo-php-atom-autocomplete.coffee
@@ -48,6 +48,9 @@ module.exports =
   providers: []
 
   activate: ->
+    if not config.testConfig()
+      return
+
     @registerProviders()
     @gotoManager = new GotoManager()
     @gotoManager.init()


### PR DESCRIPTION
Hello

This works towards a solution for issue #30 and tests that PHP and Composer can be called. If not, the package shows an error and just completely stops doing anything else. This will hopefully also cut back on the (confusing) errors and bug reports originating from incorrect setups.

Hope this helps and any feedback is of course welcome.