### PR TITLE
For variadic methods, add three dots to the last parameter.

### DIFF
--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -67,7 +67,19 @@ abstract class Tools
             }
         }
 
+        // For variadic methods, append three dots to the last argument (if any) to indicate this to the user.
+        if (!empty($args) && $method->isVariadic()) {
+            $lastArgument = $args[count($args) - 1];
+
+            if ($lastArgument->isOptional()) {
+                $optionals[count($optionals) - 1] .= '...';
+            } else {
+                $parameters[count($parameters) - 1] .= '...';
+            }
+        }
+
         $deprecated['deprecated'] = false;
+
         if ($className) {
             $parser = new DocParser();
             $return = $parser->get($className, 'method', $method->getName(), array(DocParser::RETURN_VALUE));


### PR DESCRIPTION
Hello

This adds three dots to the last parameter of variadic functions/methods, the most common example of this are many of the the built-in array functions, such as `array_map`. By adding the three dots, it is clear that after the last parameter can be repeated as many times as necessary, without creating an extra argument in autocompletion when tabbing through the argument list.