### PR TITLE
Don't show a tooltip when there is none to show and add sanity checks.

### DIFF
--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -115,15 +115,16 @@ class AbstractGoto
 
                     tooltipText = @getTooltipForWord(editor, @$(selector).text(), cursorPosition)
 
-                    @subscriptions.add atom.tooltips.add(event.target, {
-                        title: '<div style="text-align: left;">' + tooltipText + '</div>'
-                        html: true
-                        placement: 'bottom'
-                        delay:
-                            show: 500
-                    })
+                    if tooltipText?.length > 0
+                        @subscriptions.add atom.tooltips.add(event.target, {
+                            title: '<div style="text-align: left;">' + tooltipText + '</div>'
+                            html: true
+                            placement: 'bottom'
+                            delay:
+                                show: 500
+                        })
 
-                    @showingDocumentationTooltip = true
+                        @showingDocumentationTooltip = true
 
                 if event.altKey == false
                     return

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -17,6 +17,10 @@ class GotoFunction extends AbstractGoto
         bufferPosition = editor.getCursorBufferPosition()
 
         calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+
+        if not calledClassInfo?.calledClass
+            return
+
         calledClass = calledClassInfo.calledClass
         splitter = calledClassInfo.splitter
 
@@ -104,7 +108,7 @@ class GotoFunction extends AbstractGoto
         if not calledClassInfo
             calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
 
-        if not calledClassInfo
+        if not calledClassInfo?.calledClass
             return
 
         calledClass = calledClassInfo.calledClass

--- a/lib/goto/property-goto.coffee
+++ b/lib/goto/property-goto.coffee
@@ -17,6 +17,10 @@ class GotoProperty extends AbstractGoto
         bufferPosition = editor.getCursorBufferPosition()
 
         calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+
+        if not calledClassInfo?.calledClass
+            return
+
         calledClass = calledClassInfo.calledClass
         splitter = calledClassInfo.splitter
 
@@ -92,7 +96,7 @@ class GotoProperty extends AbstractGoto
         if not calledClassInfo
             calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
 
-        if not calledClassInfo
+        if not calledClassInfo?.calledClass
             return
 
         calledClass = calledClassInfo.calledClass


### PR DESCRIPTION
Hello

This adds some more sanity checks to code I recently submitted and fixes **undefined** showing up as tooltip sometimes. This was happening because the tooltip didn't check if there was actually anything to show (which there isn't for classes because it isn't implemented yet).