### PR TITLE
function-goto - Do not add a description of the thrown exception if it is null.

### DIFF
--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -84,7 +84,14 @@ class GotoFunction extends AbstractGoto
         throwsDescription = "";
 
         for exceptionType,thrownWhenDescription of value.args.throws
-            throwsDescription += "<div style='margin-left: 1em;'>• " + "<strong>" + exceptionType + "</strong>" + ' ' + thrownWhenDescription + "</div>"
+            throwsDescription +=
+                "<div style='margin-left: 1em;'>• " +
+                "<strong>" + exceptionType + "</strong>"
+
+            if thrownWhenDescription
+                throwsDescription += ' ' + thrownWhenDescription
+
+            throwsDescription += "</div>"
 
         if throwsDescription.length > 0
             description += "<br/><br/>"


### PR DESCRIPTION
Hello

This fixes an issue with the method description tooltip where a docblock such as:

```
/**
  * Description
  *
  * @throws \Exception
  */
```

... would cause the tooltip to show `\Exception null` instead of just `\Exception`.