### PR TITLE
parseStackClass - Fixed not properly handling nested method and function calls.

### DIFF
--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -260,16 +260,45 @@ module.exports =
     return @parseStackClass(text)
 
   ###*
+   * Removes content inside parantheses (including nested parantheses).
+   * @param {string} text String to analyze.
+   * @return String
+  ###
+  stripParanthesesContent: (text) ->
+    i = 0
+    openCount = 0
+    closeCount = 0
+    startIndex = -1
+
+    while i < text.length
+      if text[i] == '('
+        ++openCount
+
+        if openCount == 1
+          startIndex = i
+
+      else if text[i] == ')'
+        ++closeCount
+
+        if closeCount == openCount
+          originalLength = text.length
+          text = text.substr(0, startIndex + 1) + text.substr(i, text.length);
+
+          i -= (originalLength - text.length)
+
+          openCount = 0
+          closeCount = 0
+
+      ++i
+
+    return text
+
+  ###*
    * Parse stack class elements
    * @param {string} text String of the stack class
    * @return Array
   ###
   parseStackClass: (text) ->
-    # Remove parenthesis content
-    regx = /\((?:[^)\(\)]+|(?:[^\(\)\])]*\([^\(\)\])]*\)[^\)]*))*\)*/g
-    text = text.replace regx, (match) =>
-        return '()'
-
     # Remove singe line comments
     regx = /\/\/.*\n/g
     text = text.replace regx, (match) =>
@@ -279,6 +308,9 @@ module.exports =
     regx = /\/\*[^(\*\/)]*\*\//g
     text = text.replace regx, (match) =>
         return ''
+
+    # Remove content inside parantheses (including nested parantheses).
+    text = @stripParanthesesContent(text)
 
     # Get the full text
     return [] if not text


### PR DESCRIPTION
Hello

This further improves on my previous improvements to `parseStackClass` by properly stripping the content inside parantheses if there are nested method or function calls. The regular expression choked on this [1], causing tooltips and alt-clicking to fail.

[1] https://github.com/hotoiledgoblinsack/php-autocomplete-test/blob/943446f06ea58c61b3a09ad689d8ff5d1bb35ffa/src/TestNamespace/SomeClass.php#L311