### PR TITLE
Add annotations for method overrides and interface implementations. 

### DIFF
--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -30,6 +30,11 @@ class AbstractGoto
         @subscriptions = new CompositeDisposable
         @manager = manager
         atom.workspace.observeTextEditors (editor) =>
+            editor.onDidSave (event) =>
+                # On save, rescan for markers and annotations.
+                @cleanMarkers editor
+                @registerMarkers editor
+
             @registerMarkers editor
             @registerEvents editor
 
@@ -168,6 +173,12 @@ class AbstractGoto
      * @param  {TextEditor} editor The editor to search through
     ###
     registerMarkers: (editor) ->
+
+    ###*
+     * Removes any markers previously created by registerMarkers.
+     * @param  {TextEditor} editor The editor to search through
+    ###
+    cleanMarkers: (editor) ->
 
     ###*
      * Gets the correct selector when a selector is clicked.

--- a/lib/goto/class-goto.coffee
+++ b/lib/goto/class-goto.coffee
@@ -124,6 +124,16 @@ class GotoClass extends AbstractGoto
                 @addMarkerToCommentLine row.split(' '), parseInt(key), editor, true
 
     ###*
+     * Removes any markers previously created by registerMarkers.
+     * @param  {TextEditor} editor The editor to search through
+    ###
+    cleanMarkers: (editor) ->
+        for i,marker of @allMarkers[editor.getLongTitle()]
+            marker.destroy()
+
+        @allMarkers = []
+
+    ###*
      * Analyses the words array given for any classes and then creates a marker
      * for them.
      * @param {array} words             The array of words to check.

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -9,6 +9,7 @@ class GotoFunction extends AbstractGoto
     hoverEventSelectors: '.function-call'
     clickEventSelectors: '.function-call'
     gotoRegex: /^(\$\w+)?((->|::)\w+\()+/
+    annotationMarkers: []
 
     ###*
      * Goto the class from the term given.
@@ -148,10 +149,15 @@ class GotoFunction extends AbstractGoto
         text = editor.getText()
         rows = text.split('\n')
 
-        gutter = editor.addGutter({
-            name: 'atom-autocomplete-php-symbol-gutter',
-            priority: -1
-        });
+        gutterName = 'atom-autocomplete-php-symbol-gutter'
+
+        gutter = editor.gutterWithName(gutterName)
+
+        if not gutter
+            gutter = editor.addGutter({
+                name: gutterName,
+                priority: -1
+            });
 
         for rowNum,row of rows
             regex = /((?:public|protected|private)\ function\ )(\w+)\s*\(.*\)/g
@@ -183,6 +189,10 @@ class GotoFunction extends AbstractGoto
                         class: if value.isOverride then 'override' else 'implementation'
                     })
 
+                    if @annotationMarkers[editor.getLongTitle()] == undefined
+                        @annotationMarkers[editor.getLongTitle()] = []
+                    @annotationMarkers[editor.getLongTitle()].push(marker)
+
                     # TODO: Need something more stylish. The following problems exist:
                     #   - Can't align icons in the standard gutter right of the line numbers.
                     #   - With a custom gutter, the background can't be made transparent and looks ugly.
@@ -192,6 +202,18 @@ class GotoFunction extends AbstractGoto
                     #     isOverrideOf and isImplementationOf).
 
                     console.log("Found override/implementation", match[2], 'with', currentClass, 'value', value)
+
+
+    ###*
+     * Removes any markers previously created by registerMarkers.
+     * @param  {TextEditor} editor The editor to search through
+    ###
+    cleanMarkers: (editor) ->
+        for i,marker of @annotationMarkers[editor.getLongTitle()]
+            marker.destroy()
+
+        @annotationMarkers = []
+
 
 
     ###*

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -148,6 +148,11 @@ class GotoFunction extends AbstractGoto
         text = editor.getText()
         rows = text.split('\n')
 
+        gutter = editor.addGutter({
+            name: 'atom-autocomplete-php-symbol-gutter',
+            priority: -1
+        });
+
         for rowNum,row of rows
             regex = /((?:public|protected|private)\ function\ )(\w+)\s*\(.*\)/g
 
@@ -173,9 +178,9 @@ class GotoFunction extends AbstractGoto
                         invalidate: 'touch'
                     })
 
-                    decoration = editor.decorateMarker(marker, {
-                        type: 'line',
-                        class: if value.isOverride then 'php-atom-autocomplete-override' else 'php-atom-autocomplete-implementation'
+                    decoration = gutter.decorateMarker(marker, {
+                        type: 'line-number',
+                        class: if value.isOverride then 'override' else 'implementation'
                     })
 
                     # TODO: Need something more stylish. The following problems exist:

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -149,16 +149,6 @@ class GotoFunction extends AbstractGoto
         text = editor.getText()
         rows = text.split('\n')
 
-        gutterName = 'atom-autocomplete-php-symbol-gutter'
-
-        gutter = editor.gutterWithName(gutterName)
-
-        if not gutter
-            gutter = editor.addGutter({
-                name: gutterName,
-                priority: -1
-            });
-
         for rowNum,row of rows
             regex = /((?:public|protected|private)\ function\ )(\w+)\s*\(.*\)/g
 
@@ -184,24 +174,15 @@ class GotoFunction extends AbstractGoto
                         invalidate: 'touch'
                     })
 
-                    decoration = gutter.decorateMarker(marker, {
+                    decoration = editor.decorateMarker(marker, {
                         type: 'line-number',
                         class: if value.isOverride then 'override' else 'implementation'
                     })
 
                     if @annotationMarkers[editor.getLongTitle()] == undefined
                         @annotationMarkers[editor.getLongTitle()] = []
+
                     @annotationMarkers[editor.getLongTitle()].push(marker)
-
-                    # TODO: Need something more stylish. The following problems exist:
-                    #   - Can't align icons in the standard gutter right of the line numbers.
-                    #   - With a custom gutter, the background can't be made transparent and looks ugly.
-                    #   - Background colors are ugly.
-                    #   - We can't attach code or fetch a HTMLElement from decorations, so we can't make it clickable
-                    #     to navigate to the method being overridden (base class) or implemented (interface). (use
-                    #     isOverrideOf and isImplementationOf).
-
-                    console.log("Found override/implementation", match[2], 'with', currentClass, 'value', value)
 
 
     ###*

--- a/lib/peekmo-php-atom-autocomplete.coffee
+++ b/lib/peekmo-php-atom-autocomplete.coffee
@@ -48,10 +48,10 @@ module.exports =
   providers: []
 
   activate: ->
+    config.init()
     @registerProviders()
     @gotoManager = new GotoManager()
     @gotoManager.init()
-    config.init()
     proxy.init()
 
   deactivate: ->

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -23,42 +23,29 @@ atom-text-editor, atom-text-editor::shadow {
         z-index: 9999;
     }
 
-    .gutter[gutter-name="atom-autocomplete-php-symbol-gutter"] {
-        margin-left: 0.25em;
-        margin-right: 0.25em;;
-
-        .decoration {
-            &:before {
-                font-family: 'Octicons Regular';
-                font-weight: normal;
-                font-style: normal;
-                display: inline-block;
-                line-height: 1;
-                -webkit-font-smoothing: antialiased;
-                text-decoration: none;
-                font-size:1em;
-                width:1em;
-                height:1em;
-            }
-
+    .gutter {
+        .line-number {
             &.override {
-                visibility: visible;
+                .icon-right {
+                    opacity: 1.0;
+                    visibility: visible;
 
-                &:before {
-                    content: @link;
-                    color: @ui-site-color-2;
-
-                    z-index: 1;
+                    &:before {
+                        content: @link;
+                        color: @ui-site-color-2;
+                    }
                 }
             }
 
             &.implementation {
-                visibility: visible;
+                .icon-right {
+                    opacity: 1.0;
+                    visibility: visible;
 
-                &:before {
-                    content: @link;
-                    color: @ui-site-color-3;
-                    z-index: 1;
+                    &:before {
+                        content: @link;
+                        color: @ui-site-color-3;
+                    }
                 }
             }
         }

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -3,6 +3,7 @@
 // See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
+@import "octicon-mixins";
 
 .peekmo-php-atom-autocomplete {
 }
@@ -20,4 +21,14 @@ atom-text-editor .clickable .region,
 atom-text-editor::shadow .comment-clickable .region {
     pointer-events: all;
     z-index: 9999;
+}
+
+atom-text-editor .php-atom-autocomplete-override,
+atom-text-editor::shadow .php-atom-autocomplete-override {
+    background-color: @ui-site-color-1;
+}
+
+atom-text-editor .php-atom-autocomplete-implementation,
+atom-text-editor::shadow .php-atom-autocomplete-implementation {
+    background-color: @ui-site-color-2;
 }

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -3,7 +3,7 @@
 // See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
-@import "octicon-mixins";
+@import "octicon-utf-codes";
 
 .peekmo-php-atom-autocomplete {
 }
@@ -17,18 +17,50 @@
     margin-left: -50%;
 }
 
-atom-text-editor .clickable .region,
-atom-text-editor::shadow .comment-clickable .region {
-    pointer-events: all;
-    z-index: 9999;
-}
+atom-text-editor, atom-text-editor::shadow {
+    .comment-clickable .region {
+        pointer-events: all;
+        z-index: 9999;
+    }
 
-atom-text-editor .php-atom-autocomplete-override,
-atom-text-editor::shadow .php-atom-autocomplete-override {
-    background-color: @ui-site-color-1;
-}
+    .gutter[gutter-name="atom-autocomplete-php-symbol-gutter"] {
+        margin-left: 0.25em;
+        margin-right: 0.25em;;
 
-atom-text-editor .php-atom-autocomplete-implementation,
-atom-text-editor::shadow .php-atom-autocomplete-implementation {
-    background-color: @ui-site-color-2;
+        .decoration {
+            &:before {
+                font-family: 'Octicons Regular';
+                font-weight: normal;
+                font-style: normal;
+                display: inline-block;
+                line-height: 1;
+                -webkit-font-smoothing: antialiased;
+                text-decoration: none;
+                font-size:1em;
+                width:1em;
+                height:1em;
+            }
+
+            &.override {
+                visibility: visible;
+
+                &:before {
+                    content: @link;
+                    color: @ui-site-color-2;
+
+                    z-index: 1;
+                }
+            }
+
+            &.implementation {
+                visibility: visible;
+
+                &:before {
+                    content: @link;
+                    color: @ui-site-color-3;
+                    z-index: 1;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hello

This adds basic support for annotating overrides of methods for classes as well as interface implementations (both in a different color). The annotations are added to the default gutter when the markers are registered (at the same time as the goto markers). I've also let the annotations as well as the goto markers be reset and rescanned when a file is saved.

On the PHP side, I also provided `isImplementationOf` and `isOverrideOf`, as I thought it would be really nice to be able to have tooltips on the annotation or be able to click through to the respective class (we already have the information anyway), but I haven't been able to figure out how to do this yet and figured that even in its current state, this is already useful and we can always add it later.

Hopefully this will be a major help for people that often work with subclasses and interfaces so they can easily see what method originates from a base class or an interface.

@Peekmo For when you get back and are able to review this: I merged most of my pull requests in my fork's master branch, some of them will generate minor conflicts which I've already resolved there. If it's easier for you, I can always create a larger pull request, you can pull the changes from there, or simply view them to see the conflict resolution I performed. 