### PR TITLE
Enhancement - Clickable annotations with tooltips.

### DIFF
--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -191,15 +191,57 @@ class GotoFunction extends AbstractGoto
                         invalidate: 'touch'
                     })
 
+                    annotationClass = if value.isOverride then 'override' else 'implementation'
+
                     decoration = editor.decorateMarker(marker, {
                         type: 'line-number',
-                        class: if value.isOverride then 'override' else 'implementation'
+                        class: annotationClass
                     })
 
                     if @annotationMarkers[editor.getLongTitle()] == undefined
                         @annotationMarkers[editor.getLongTitle()] = []
 
                     @annotationMarkers[editor.getLongTitle()].push(marker)
+
+
+
+
+
+                    # Add tooltips and click handlers to the annotations.
+
+                    # TODO: This was duplicated from abstract-goto, refactor later. Also stop fetching this in the loop.
+
+                    textEditorElement = atom.views.getView(editor)
+                    gutterContainerElement = @$(textEditorElement.shadowRoot).find('.gutter-container')
+
+                    selector = '.line-number-' + rowNum + '.' + annotationClass
+
+                    # TODO: Also do/test implementations.
+                    # TODO: Register a click handler that navigates to the parent method or interface method (using
+                    #       isOverrideOf and isImplementationOf).
+                    # TODO: Register mouse out and remove disposables (or somehow do this on load), must these also be
+                    # removed on cleanMarkers?
+                    # TODO: Find a way to do this on load, tooltips can permanently be attached to a node, we don't want
+                    # to have to attach them on mouse over and then dispose them on mouse out as this is completely
+                    # unnecessary.
+                    # TODO:    -> The same applies to the tooltips used for methods and functions, but we must make sure
+                    #             that if this is indeed changed for those tooltips, that they are also reconnected on
+                    #             save, like these markers, or changes to docblocks will not propagate to tooltips.
+
+                    @subAtom.add gutterContainerElement, 'dom-ready', selector, (event) =>
+                        debugger
+                        tooltipText = (if value.isOverride then 'Override' else 'Implementation') + ' of ' + '?'
+
+                        @subscriptions.add atom.tooltips.add(event.target, {
+                            title: '<div style="text-align: left;">' + tooltipText + '</div>'
+                            html: true
+                            placement: 'bottom'
+                            delay:
+                                show: 0
+                        })
+
+
+
 
 
     ###*

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -28,6 +28,7 @@ atom-text-editor, atom-text-editor::shadow {
             &.override {
                 .icon-right {
                     opacity: 1.0;
+                    cursor: pointer;
                     visibility: visible;
 
                     &:before {
@@ -40,6 +41,7 @@ atom-text-editor, atom-text-editor::shadow {
             &.implementation {
                 .icon-right {
                     opacity: 1.0;
+                    cursor: pointer;
                     visibility: visible;
 
                     &:before {


### PR DESCRIPTION
Hello

In pull request #87 I added support for annotations and noted that I wanted to make them clickable and give them tooltips. Well... now I have ;-). With this pull request you can hover over the annotation in the gutter to see what the annotation actually means and which class or interface the method you're overriding/implementing originates from. You can then click the annotation to navigate to the method in that class or interface. 

This also fixes a bug where ```cleanMarkers``` made ```annotationMarkers``` completely empty for all files, instead of just for the current file.