### PR TITLE
Bugfix / Refactoring - Fix annotation event handlers no longer working in Atom 1.0.12.

### DIFF
--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -13,7 +13,6 @@ class AbstractGoto
     clickEventSelectors: ''
     manager: {}
     gotoRegex: ''
-    jumpLine: null
     jumpWord: ''
 
     ###*
@@ -40,8 +39,7 @@ class AbstractGoto
 
         atom.workspace.onDidChangeActivePaneItem (paneItem) =>
             if paneItem instanceof TextEditor && @jumpWord != '' && @jumpWord != undefined
-                @jumpTo(paneItem, @jumpWord, @jumpLine)
-                @jumpLine = null
+                @jumpTo(paneItem, @jumpWord)
                 @jumpWord = ''
 
         # When you go back to only have 1 pane the events are lost, so need
@@ -240,8 +238,8 @@ class AbstractGoto
      * @param  {string} word       The word to find and then jump to.
      * @return {boolean}           Whether the finding was successful.
     ###
-    jumpTo: (editor, word, line) ->
-        bufferPosition = @parser.findBufferPositionOfWord(editor, word, @getJumpToRegex(word), line)
+    jumpTo: (editor, word) ->
+        bufferPosition = @parser.findBufferPositionOfWord(editor, word, @getJumpToRegex(word))
         if bufferPosition == null
             return false
 

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -220,29 +220,33 @@ abstract class Tools
             $methodName = $method->getName();
 
             // Check if this method overrides a base class method.
-            $isOverride = false;
-            $isOverrideOf = null;
+            $overrideData = null;
 
             $baseClass = $reflection;
 
             if ($method->getDeclaringClass() == $reflection) {
                 while ($baseClass = $baseClass->getParentClass()) {
                     if ($baseClass->hasMethod($methodName)) {
-                        $isOverride = true;
-                        $isOverrideOf = $baseClass->getName();
+                        $overrideData = array(
+                            'baseClass'           => $baseClass->getName(),
+                            'baseMethodStartLine' => $baseClass->getMethod($methodName)->getStartLine()
+                        );
+
                         break;
                     }
                 }
             }
 
             // Check if this method implements an interface method.
-            $isImplementation = false;
-            $isImplementationOf = null;
+            $implementationData = null;
 
             foreach ($interfaces as $interface) {
                 if ($interface->hasMethod($methodName)) {
-                    $isImplementation = true;
-                    $isImplementationOf = $interface->getName();
+                    $implementationData = array(
+                        'interfaceName'            => $interface->getName(),
+                        'interfaceMethodStartLine' => $interface->getMethod($methodName)->getStartLine()
+                    );
+
                     break;
                 }
             }
@@ -251,10 +255,10 @@ abstract class Tools
                 'isMethod'           => true,
                 'isPublic'           => $method->isPublic(),
                 'isProtected'        => $method->isProtected(),
-                'isOverride'         => $isOverride,
-                'isOverrideOf'       => $isOverrideOf,
-                'isImplementation'   => $isImplementation,
-                'isImplementationOf' => $isImplementationOf,
+
+                'override'           => $overrideData,
+                'implementation'     => $implementationData,
+
                 'args'               => $this->getMethodArguments($method),
                 'declaringClass'     => $method->getDeclaringClass()->name,
                 'startLine'          => $method->getStartLine()


### PR DESCRIPTION
Hello

It turns out that in Atom v1.0.12, the class names used by the default gutter have changed, causing event handlers on annotations to no longer be registered. It seems they now just give a `.line-number` class to each line and no longer a `.line-number-X` (with X the number of the row), which wasn't documented in the official release notes. 

Apart from that, this also replaces the use of `jumpWord` and `jumpLine` in places where the line was already known beforehand. Atom now supports jumping to a specific line by specifying the `initialLine` option, which removes the need for our manual jumping after a specific timeout. Sadly this can't replace all our uses, as some of them rely on scanning the file based on a regex after opening it. Because of this I only refactored out `jumpLine` entirely, as it is now obsolete, but left the other code intact. 