### PR TITLE
Bugfix - Also handle static:: in self-provider.

### DIFF
--- a/lib/providers/self-provider.coffee
+++ b/lib/providers/self-provider.coffee
@@ -7,7 +7,7 @@ AbstractProvider = require "./abstract-provider.coffee"
 
 module.exports =
 # Autocomplete for static methods and constants inside a class
-# (keyword self::)
+# (keyword self:: and static::)
 class SelfProvider extends AbstractProvider
   statics: []
   functionOnly: true
@@ -17,7 +17,7 @@ class SelfProvider extends AbstractProvider
    * @return array
   ###
   fetchSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
-    @regex = /(\bself::([a-zA-Z_]*))/g
+    @regex = /(\b(self|static)::([a-zA-Z_]*))/g
 
     prefix = @getPrefix(editor, bufferPosition)
     return unless prefix.length


### PR DESCRIPTION
Hello

The `static` keyword can be used to apply late static binding of static methods, which the `self` keyword does not apply. If I understand correctly (correct me if I'm wrong ;-), as the child class can be anything from the perspective of the class using the `static` keyword, it should probably be treated the same as the `self` keyword.