### PR TITLE
Bugfix - Fix several issues with constants and static properties.

### DIFF
--- a/lib/providers/autocomplete-provider.coffee
+++ b/lib/providers/autocomplete-provider.coffee
@@ -81,7 +81,7 @@ class AutocompleteProvider extends AbstractProvider
     else
       suggestions.push
         text: word,
-        type: 'property'
+        type: if element.isProperty then 'property' else 'constant'
         leftLabel: returnValues[returnValues.length - 1]
         description: if element.args.descriptions.short? then element.args.descriptions.short else ''
         className: if element.args.deprecated then 'php-atom-autocomplete-strike' else ''

--- a/lib/providers/self-provider.coffee
+++ b/lib/providers/self-provider.coffee
@@ -42,27 +42,46 @@ class SelfProvider extends AbstractProvider
     # Builds suggestions for the words
     suggestions = []
     for word in words
-      for element in @statics.values[word]
-        # Methods
-        if element.isMethod
-          suggestions.push
-            text: word,
-            type: 'method',
-            snippet: @getFunctionSnippet(word, element.args),
-            replacementPrefix: prefix,
-            leftLabel: element.args.return,
-            description: if element.args.descriptions.short? then element.args.descriptions.short else ''
-            data:
-              prefix: prefix,
-              args: element.args
+      element = @statics.values[word]
+      if element instanceof Array
+        for ele in element
+          suggestions = @addSuggestion(word, ele, suggestions, prefix)
+      else
+        suggestions = @addSuggestion(word, element, suggestions, prefix)
 
-        # Constants and public properties
-        else
-          suggestions.push
-            text: word,
-            type: 'constant',
-            replacementPrefix: prefix,
-            data:
-              prefix: prefix
+    return suggestions
+
+  ###*
+   * Adds the suggestion the the suggestions array.
+   * @param {string} word        The word being currently typed.
+   * @param {object} element     The object returns from proxy.methods.
+   * @param {array} suggestions  An array of suggestions for the current word.
+   * @param {string} word        The prefix to insert for the suggestion.
+  ###
+  addSuggestion: (word, element, suggestions, prefix) ->
+    # Methods
+    if element.isMethod
+      suggestions.push
+        text: word,
+        type: 'method',
+        snippet: @getFunctionSnippet(word, element.args),
+        replacementPrefix: prefix,
+        leftLabel: element.args.return,
+        description: if element.args.descriptions.short? then element.args.descriptions.short else ''
+        data:
+          prefix: prefix,
+          args: element.args
+
+    # Constants and public properties
+    else
+      suggestions.push
+        text: word,
+        type: if element.isProperty then 'property' else 'constant'
+        leftLabel: element.args.return
+        description: if element.args.descriptions.short? then element.args.descriptions.short else ''
+        className: if element.args.deprecated then 'php-atom-autocomplete-strike' else ''
+        replacementPrefix: prefix,
+        data:
+          prefix: prefix
 
     return suggestions

--- a/lib/providers/static-provider.coffee
+++ b/lib/providers/static-provider.coffee
@@ -41,28 +41,47 @@ class StaticProvider extends AbstractProvider
     # Builds suggestions for the words
     suggestions = []
     for word in words
-      for element in @statics.values[word]
-        if element.isPublic
-          # Methods
-          if element.isMethod
-            suggestions.push
-              text: word,
-              type: 'method',
-              snippet: @getFunctionSnippet(word, element.args),
-              replacementPrefix: prefix,
-              leftLabel: element.args.return,
-              description: if element.args.descriptions.short? then element.args.descriptions.short else ''
-              data:
-                prefix: prefix,
-                args: element.args
+      element = @statics.values[word]
+      if element instanceof Array
+        for ele in element
+          suggestions = @addSuggestion(word, ele, suggestions, prefix)
+      else
+        suggestions = @addSuggestion(word, element, suggestions, prefix)
 
-          # Constants and public properties
-          else
-            suggestions.push
-              text: word,
-              type: 'constant',
-              replacementPrefix: prefix,
-              data:
-                prefix: prefix
+    return suggestions
+
+  ###*
+   * Adds the suggestion the the suggestions array.
+   * @param {string} word        The word being currently typed.
+   * @param {object} element     The object returns from proxy.methods.
+   * @param {array} suggestions  An array of suggestions for the current word.
+   * @param {string} word        The prefix to insert for the suggestion.
+  ###
+  addSuggestion: (word, element, suggestions, prefix) ->
+    if element.isPublic
+      # Methods
+      if element.isMethod
+        suggestions.push
+          text: word,
+          type: 'method',
+          snippet: @getFunctionSnippet(word, element.args),
+          replacementPrefix: prefix,
+          leftLabel: element.args.return,
+          description: if element.args.descriptions.short? then element.args.descriptions.short else ''
+          data:
+            prefix: prefix,
+            args: element.args
+
+      # Constants and public static properties
+      else
+        suggestions.push
+          text: word,
+          type: if element.isProperty then 'property' else 'constant'
+          leftLabel: element.args.return
+          description: if element.args.descriptions.short? then element.args.descriptions.short else ''
+          className: if element.args.deprecated then 'php-atom-autocomplete-strike' else ''
+          replacementPrefix: prefix,
+          data:
+            prefix: prefix
 
     return suggestions

--- a/php/providers/StaticsProvider.php
+++ b/php/providers/StaticsProvider.php
@@ -11,63 +11,6 @@ class StaticsProvider extends Tools implements ProviderInterface
     {
         $class = $args[0];
 
-        $statics = array(
-            'class'  => $class,
-            'names'  => array(),
-            'values' => array()
-        );
-
-        try {
-            $reflection = new ReflectionClass($class);
-        } catch (Exception $e) {
-            return $statics;
-        }
-
-        $methods    = $reflection->getMethods(ReflectionMethod::IS_STATIC);
-        $constants  = $reflection->getConstants();
-        $attributes = $reflection->getProperties(ReflectionProperty::IS_STATIC);
-
-        // Methods
-        foreach ($methods as $method) {
-            $statics['names'][] = $method->getName();
-
-            $args = $this->getMethodArguments($method); 
-
-            $statics['values'][$method->getName()] = array(
-                array(
-                    'isMethod' => true,
-                    'isPublic' => $method->isPublic(),
-                    'args'     => $args
-                )
-            );
-        }
-
-        // Constants
-        foreach ($constants as $constant => $value) {
-            if (!in_array($constant, $statics['names'])) {
-                $statics['names'][] = $constant;
-                $statics['values'][$constant] = array();
-            }
-
-            $statics['values'][$constant][] = array(
-                'isMethod' => false,
-                'isPublic' => true
-            );
-        }
-
-        // Properties
-        foreach ($attributes as $attribute) {
-            if (!in_array($attribute->getName(), $statics['names'])) {
-                $statics['names'][] = $attribute->getName();
-                $statics['values'][$attribute->getName()] = array();
-            }
-
-            $statics['values'][$attribute->getName()][] = array(
-                'isMethod' => false,
-                'isPublic' => $attribute->isPublic()
-            );
-        }
-
-        return $statics;
+        return $this->getClassMetadata($class, ReflectionMethod::IS_STATIC, ReflectionProperty::IS_STATIC);
     }
 }


### PR DESCRIPTION
Hello

This fixes a couple of issues I noticed, mostly with completion of static properties and constants:
  * `self-provider` and `static-provider` assumed that when an entry was not a record, it must be a constant, it could however also be a (static) property, which should have a different style class in autocomplete-plus.
  * `StaticsProvider::execute` duplicated a lot of code from `Tools::getClassMetadata` and was outdated, the former now uses the latter directly.
  * Constant fetching was added to `Tools::getClassMetadata`, resulting constants to also be listed for `$this->`. This may seem strange, but e.g. `$this->MY_CONSTANT` is correct PHP code (I however wouldn't advise using it ;-).