### PR TITLE
Bugfix - Fixed findUseForClass not skipping comments when exiting early.

### DIFF
--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -86,12 +86,17 @@ module.exports =
     text = editor.getText()
 
     lines = text.split('\n')
-    for line in lines
+    for line,i in lines
       line = line.trim()
 
       # If we found class keyword, we are not in namespace space, so return the className
-      if line.indexOf('class ') != -1
-        break
+      classIndex = line.indexOf('class ')
+
+      if classIndex != -1
+        chain = editor.scopeDescriptorForBufferPosition([i, classIndex]).getScopeChain()
+
+        if chain.indexOf('.comment') == -1
+          break
 
       # Use keyword
       if line.indexOf('use') == 0


### PR DESCRIPTION
Hello

I had some files where I couldn't alt-click some methods that should have been working correctly which I also couldn't reproduce in an isolated environment. Then it turned out this was the culprit:

```
<?php
/**
 * Blah class.
 *
 * ...
 */

namespace X;

use ...
```

Because `findUseForClass` exits early when it finds the word `class`, it was stumbling over the docblock at the top of the file and not scanning any of the use statements. This corrects that by checking if the location the word was found is a comment.