### PR TITLE
Bugfix - Replace newlines with line breaks for the tooltip.

### DIFF
--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -120,7 +120,7 @@ class AbstractGoto
 
                     if tooltipText?.length > 0
                         @subscriptions.add atom.tooltips.add(event.target, {
-                            title: '<div style="text-align: left;">' + tooltipText + '</div>'
+                            title: '<div style="text-align: left;">' + tooltipText.replace(/\n/g, '<br/>') + '</div>'
                             html: true
                             placement: 'bottom'
                             delay:


### PR DESCRIPTION
Hello

This adds line breaks to the method tooltip in the same places as there was a newline. This ensures that if you have a multiline summary of (long) description in your docblock, the tooltip will have the lines broken at the same locations as the original docblock. This also fixes the issue where the tooltips could get incredibly wide.