### PR TITLE
Enhancement - Improve method tooltips.

### DIFF
--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -121,6 +121,12 @@ class GotoFunction extends AbstractGoto
             description +=     "<div style='padding-left: 1em;'>" + parametersDescription + "</div>"
             description += "</p>"
 
+        if value.args.return
+            description += "<p>"
+            description +=     "<div>Returns:</div>"
+            description +=     "<div style='padding-left: 1em;'>" + value.args.return + "</div>"
+            description += "</p>"
+
         # Show an overview of the exceptions the method can throw.
         throwsDescription = ""
 

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -70,7 +70,7 @@ class GotoFunction extends AbstractGoto
 
         # Show the method's signature.
         description += '<div style="margin-top: -1em; margin-bottom: -1em;">'
-        returnType = (if value.args.return then value.args.return else 'void')
+        returnType = (if value.args.return then value.args.return else '')
 
         description += "<p><div>"
         description += returnType + ' <strong>' + term + '</strong>' + '('

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -66,10 +66,14 @@ class GotoFunction extends AbstractGoto
         if not value
             return
 
-        # Show the method's signature.
-        returnType = if value.args.return then value.args.return else 'void'
+        description = ""
 
-        description = returnType + ' <strong>' + term + '</strong>' + '('
+        # Show the method's signature.
+        description += '<div style="margin-top: -1em; margin-bottom: -1em;">'
+        returnType = (if value.args.return then value.args.return else 'void')
+
+        description += "<p><div>"
+        description += returnType + ' <strong>' + term + '</strong>' + '('
 
         if value.args.parameters.length > 0
             description += value.args.parameters.join(', ');
@@ -84,34 +88,58 @@ class GotoFunction extends AbstractGoto
             description += ']'
 
         description += ')'
+        description += '</div></p>'
 
         # Show the summary (short description) of the method.
-        description += "<br/><br/>"
-        description += '<span>' + (if value.args.descriptions.short then value.args.descriptions.short else '(No documentation available)') + '</span>';
+        description += '<p><div>'
+        description +=     (if value.args.descriptions.short then value.args.descriptions.short else '(No documentation available)')
+        description += '</p></div>'
 
         # Show the (long) description of the method.
         if value.args.descriptions.long?.length > 0
-            description += "<br/><br/>"
-            description += "Description:<br/>"
-            description += "<span style='margin-left: 1em;'>" + value.args.descriptions.long + "</span>"
+            description += "<p>"
+            description +=     "<div>Description:</div>"
+            description +=     "<div style='padding-left: 1em;'>" + value.args.descriptions.long + "</div>"
+            description += "</p>"
+
+        # Show the parameters the method has.
+        parametersDescription = ""
+
+        for param in value.args.parameters
+            parametersDescription += "<div>"
+            parametersDescription += "• <strong>" + param + "</strong>"
+            parametersDescription += "</div>"
+
+        for param in value.args.optionals
+            parametersDescription += "<div>"
+            parametersDescription += "• <strong>" + param + "</strong>"
+            parametersDescription += "</div>"
+
+        if value.args.parameters.length > 0 or value.args.optionals.length > 0
+            description += "<p>"
+            description +=     "<div>Parameters:</div>"
+            description +=     "<div style='padding-left: 1em;'>" + parametersDescription + "</div>"
+            description += "</p>"
 
         # Show an overview of the exceptions the method can throw.
-        throwsDescription = "";
+        throwsDescription = ""
 
         for exceptionType,thrownWhenDescription of value.args.throws
-            throwsDescription +=
-                "<span style='margin-left: 1em;'>• " +
-                "<strong>" + exceptionType + "</strong>"
+            throwsDescription += "<div>"
+            throwsDescription += "• <strong>" + exceptionType + "</strong>"
 
             if thrownWhenDescription
                 throwsDescription += ' ' + thrownWhenDescription
 
-            throwsDescription += "</span><br/>"
+            throwsDescription += "</div>"
 
         if throwsDescription.length > 0
-            description += "<br/><br/>"
-            description += "Throws:<br/>"
-            description += throwsDescription
+            description += "<p>"
+            description +=     "<div>Throws:</div>"
+            description +=     "<div style='margin-left: 1em;'>" + throwsDescription + "</div>"
+            description += "</p>"
+
+        description += "</div>"
 
         return description
 

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -83,14 +83,14 @@ abstract class Tools
         }
 
         $parser = new DocParser();
-        $docComment = $function->getDocComment() ?: '';
+        $docComment = $function->getDocComment();
 
         $docParseResult = $parser->parse($docComment, array(
             DocParser::THROWS,
             DocParser::DEPRECATED,
             DocParser::DESCRIPTION,
             DocParser::RETURN_VALUE
-        ));
+        ), ($function->name === '__construct'));
 
         $docblockInheritsLongDescription = false;
 
@@ -158,7 +158,7 @@ abstract class Tools
             DocParser::VAR_TYPE,
             DocParser::DEPRECATED,
             DocParser::DESCRIPTION
-        ));
+        ), false);
 
         if (!$docComment) {
             $classIterator = new ReflectionClass($property->class);


### PR DESCRIPTION
Hello

This pull request contains the following changes:
  * The method tooltip now uses `div`s instead of `span`s. This resolves the issue where only the first line of the description and summary would have a margin when it spanned multiple lines.
  * The method tooltip now shows the parameters and return type of a method (without their description, for now).
  * The long description will now no longer trim out extra newlines that you added in the docblock for clarity.
  * The summary and long description will no longer filter out any asterisks or slashes inside the string itself.
  * `DocParser` will now differentiate between no docblock or a docblock without a `@return` tag. This is because, according to the phpDocumentor documentation, a docblock without a return tag implies `@return void`, whilst for constructors it implies `@return self`. When no docblock is available, we can't assume the method returns void so it now just leaves the return type out during autocompletion to explicitely indicate that it is unknown.

I also wanted to ask for your input on the tooltips: as you can see, the tooltip is growing larger and larger as more information is added. I was thinking that perhaps we should only show the method signature and the summary by default, and show all the information if you hold down the alt modifier key while hovering over the method? What do you think?