### PR TITLE
[Proposal] Add a namespace to all PHP classes to avoid Reflection conflicts

### DIFF
--- a/php/Config.php
+++ b/php/Config.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 /**
  * Contains all configuration options
  */

--- a/php/ErrorHandler.php
+++ b/php/ErrorHandler.php
@@ -5,6 +5,8 @@
  * Output PHP errors and exceptions in JSON.
  **/
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class ErrorHandler
 {
     static private $reserve;

--- a/php/parser.php
+++ b/php/parser.php
@@ -6,6 +6,10 @@
  * This script returns all functions, classes & methods in the given directory.
  * Internals and user's one
  **/
+
+use Peekmo\AtomAutocompletePhp\ErrorHandler;
+use Peekmo\AtomAutocompletePhp\Config;
+
 require_once(__DIR__ . '/ErrorHandler.php');
 ErrorHandler::register();
 
@@ -27,16 +31,16 @@ require_once(__DIR__ . '/providers/ParentProvider.php');
 require_once(__DIR__ . '/providers/DocParamProvider.php');
 
 $commands = array(
-    '--classes'          => 'ClassesProvider',
-    '--class'            => 'ClassProvider',
-    '--statics'          => 'StaticsProvider',
-    '--methods'          => 'MethodsProvider',
-    '--functions'        => 'FunctionsProvider',
-    '--refresh'          => 'ClassMapRefresh',
-    '--autocomplete'     => 'AutocompleteProvider',
-    '--autoloadClassMap' => 'AutoloadClassMap',
-    '--parent'           => 'ParentProvider',
-    '--doc-params'       => 'DocParamProvider'
+    '--classes'          => 'Peekmo\AtomAutocompletePhp\ClassesProvider',
+    '--class'            => 'Peekmo\AtomAutocompletePhp\ClassProvider',
+    '--statics'          => 'Peekmo\AtomAutocompletePhp\StaticsProvider',
+    '--methods'          => 'Peekmo\AtomAutocompletePhp\MethodsProvider',
+    '--functions'        => 'Peekmo\AtomAutocompletePhp\FunctionsProvider',
+    '--refresh'          => 'Peekmo\AtomAutocompletePhp\ClassMapRefresh',
+    '--autocomplete'     => 'Peekmo\AtomAutocompletePhp\AutocompleteProvider',
+    '--autoloadClassMap' => 'Peekmo\AtomAutocompletePhp\AutoloadClassMap',
+    '--parent'           => 'Peekmo\AtomAutocompletePhp\ParentProvider',
+    '--doc-params'       => 'Peekmo\AtomAutocompletePhp\DocParamProvider'
 );
 
 /**

--- a/php/providers/AutocompleteProvider.php
+++ b/php/providers/AutocompleteProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class AutocompleteProvider extends Tools implements ProviderInterface
 {
     /**
@@ -52,8 +54,8 @@ class AutocompleteProvider extends Tools implements ProviderInterface
             // Look into its parents if use not found
             if (!$found) {
                 try {
-                    $reflection = new ReflectionClass($class);
-                } catch (Exception $e) {
+                    $reflection = new \ReflectionClass($class);
+                } catch (\Exception $e) {
                     return $className;
                 }
 

--- a/php/providers/AutoloadClassMap.php
+++ b/php/providers/AutoloadClassMap.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class AutoloadClassMap extends Tools implements ProviderInterface
 {
     /**

--- a/php/providers/ClassMapRefresh.php
+++ b/php/providers/ClassMapRefresh.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class ClassMapRefresh extends Tools implements ProviderInterface
 {
     /**

--- a/php/providers/ClassProvider.php
+++ b/php/providers/ClassProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class ClassProvider extends Tools implements ProviderInterface
 {
     /**
@@ -12,8 +14,8 @@ class ClassProvider extends Tools implements ProviderInterface
         $class = $args[0];
 
         try {
-            $reflection = new ReflectionClass($class);
-        } catch (Exception $e) {
+            $reflection = new \ReflectionClass($class);
+        } catch (\Exception $e) {
             return array('error' => $e->getMessage());
         }
 

--- a/php/providers/ClassesProvider.php
+++ b/php/providers/ClassesProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class ClassesProvider extends Tools implements ProviderInterface
 {
     /**

--- a/php/providers/DocParamProvider.php
+++ b/php/providers/DocParamProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class DocParamProvider extends Tools implements ProviderInterface
 {
     /**

--- a/php/providers/FunctionsProvider.php
+++ b/php/providers/FunctionsProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class FunctionsProvider extends Tools implements ProviderInterface
 {
     /**
@@ -18,14 +20,14 @@ class FunctionsProvider extends Tools implements ProviderInterface
 
         foreach ($functions['internal'] as $functionName) {
             try {
-                $function = new ReflectionFunction($functionName);
-            } catch (Exception $e) {
+                $function = new \ReflectionFunction($functionName);
+            } catch (\Exception $e) {
                 continue;
             }
 
             $functions['names'][] = $function->getName();
 
-            $args = $this->getMethodArguments($function); 
+            $args = $this->getMethodArguments($function);
 
             $functions['values'][$function->getName()] = array(
                 array(

--- a/php/providers/MethodsProvider.php
+++ b/php/providers/MethodsProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class MethodsProvider extends Tools implements ProviderInterface
 {
     /**

--- a/php/providers/ParentProvider.php
+++ b/php/providers/ParentProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 /**
  * Autocompletion for "parent"
  */
@@ -16,8 +18,8 @@ class ParentProvider extends Tools implements ProviderInterface
 
          // Get the reflection to find the parent
         try {
-            $reflection = new ReflectionClass($class);
-        } catch (Exception $e) {
+            $reflection = new \ReflectionClass($class);
+        } catch (\Exception $e) {
             return $this->getClassMetadata('WhatTheHeeeeeeeeell');
         }
 

--- a/php/providers/ProviderInterface.php
+++ b/php/providers/ProviderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 interface ProviderInterface
 {
     /**

--- a/php/providers/StaticsProvider.php
+++ b/php/providers/StaticsProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class StaticsProvider extends Tools implements ProviderInterface
 {
     /**
@@ -11,6 +13,6 @@ class StaticsProvider extends Tools implements ProviderInterface
     {
         $class = $args[0];
 
-        return $this->getClassMetadata($class, ReflectionMethod::IS_STATIC, ReflectionProperty::IS_STATIC);
+        return $this->getClassMetadata($class, \ReflectionMethod::IS_STATIC, \ReflectionProperty::IS_STATIC);
     }
 }

--- a/php/services/DocParser.php
+++ b/php/services/DocParser.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 /**
  * Parser for PHP documentation
  */
@@ -29,16 +31,16 @@ class DocParser
 
         switch($type) {
             case 'function':
-                $reflection = new ReflectionFunction($name);
+                $reflection = new \ReflectionFunction($name);
                 break;
 
             case 'method':
                 $isConstructor = ($name === '__construct');
-                $reflection = new ReflectionMethod($className, $name);
+                $reflection = new \ReflectionMethod($className, $name);
                 break;
 
             case 'property':
-                $reflection = new ReflectionProperty($className, $name);
+                $reflection = new \ReflectionProperty($className, $name);
                 break;
 
             default:

--- a/php/services/FileParser.php
+++ b/php/services/FileParser.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 class FileParser
 {
     const USE_PATTERN = '/(?:use)(?:[^\w\\\\])([\w\\\\]+)(?![\w\\\\])(?:(?:[ ]+as[ ]+)(\w+))?(?:;)/';

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Peekmo\AtomAutocompletePhp;
+
 abstract class Tools
 {
     /**
@@ -49,7 +51,7 @@ abstract class Tools
      *
      * @return array
      */
-    protected function getMethodArguments(ReflectionFunctionAbstract $function)
+    protected function getMethodArguments(\ReflectionFunctionAbstract $function)
     {
         $args = $function->getParameters();
 
@@ -101,8 +103,8 @@ abstract class Tools
         }
 
         // No immediate docblock available or we need to scan the parent docblock?
-        if ((!$docComment || $docblockInheritsLongDescription) && $function instanceof ReflectionMethod) {
-            $classIterator = new ReflectionClass($function->class);
+        if ((!$docComment || $docblockInheritsLongDescription) && $function instanceof \ReflectionMethod) {
+            $classIterator = new \ReflectionClass($function->class);
             $classIterator = $classIterator->getParentClass();
 
             // Walk up base classes to see if any of them have additional info about this method.
@@ -149,7 +151,7 @@ abstract class Tools
       *
       * @return array
       */
-    protected function getPropertyArguments(ReflectionProperty $property)
+    protected function getPropertyArguments(\ReflectionProperty $property)
     {
         $parser = new DocParser();
         $docComment = $property->getDocComment() ?: '';
@@ -161,7 +163,7 @@ abstract class Tools
         ), false);
 
         if (!$docComment) {
-            $classIterator = new ReflectionClass($property->class);
+            $classIterator = new \ReflectionClass($property->class);
             $classIterator = $classIterator->getParentClass();
 
             // Walk up base classes to see if any of them have additional info about this property.
@@ -205,8 +207,8 @@ abstract class Tools
         );
 
         try {
-            $reflection = new ReflectionClass($className);
-        } catch (Exception $e) {
+            $reflection = new \ReflectionClass($className);
+        } catch (\Exception $e) {
             return $data;
         }
 


### PR DESCRIPTION
Exemple : In Prestashop, we have a "Tools" class without namespace. There's a "Tools" class in this package, Reflection is done on the wrong source class.