### PR TITLE
Bugfix - Fixed getCompleteNamespace being too greedy.

### DIFF
--- a/php/services/FileParser.php
+++ b/php/services/FileParser.php
@@ -59,9 +59,23 @@ class FileParser
                 if (isset($matches[2]) && $matches[2] == $className) {
                     $found = true;
                     return $matches[1];
-                } else if (substr($matches[1], strlen($matches[1]) - strlen($className)) == $className) {
-                    $found = true;
-                    return $matches[1];
+                } elseif (substr($matches[1], -strlen($className)) === $className) {
+                    $isOnlyPartOfClassName = false;
+
+                    // If we're looking for the class name 'Mailer', a use statement such as "use \My_Mailer" should not
+                    // pass the check.
+                    if (strlen($matches[1]) > strlen($className)) {
+                        $characterBeforeClassName = substr($matches[1], -strlen($className) - 1, 1);
+
+                        if ($characterBeforeClassName !== "\\" && $characterBeforeClassName !== ' ') {
+                            $isOnlyPartOfClassName = true;
+                        }
+                    }
+
+                    if (!$isOnlyPartOfClassName) {
+                        $found = true;
+                        return $matches[1];
+                    }
                 }
             }
 


### PR DESCRIPTION
Hello

`getCompleteNamespace` in `FileParser` was being too greedy and also matching use statements that ended in the class searched for. For example:

```
namespace SomeNamespace;

use \MyMailer;

class Mailer
{
    /**
      * @return Mailer
      */
   public function foo()
   {
        // ...
   }
}
```

Here, when alt-clicking the `foo` method for an instance of Mailer, `AutocompleteProvider` would return `MyMailer` because it analyzes the end of the use statement, ignoring whether it is only part of the name or the complete name. This adds a simple check that assumes if the part matched is not preceded by a backslash or a space, then it is not the entire name.

Hope this helps.