### PR TITLE
Bugfix - Fixed self being treated the same way as $this and static.

### DIFF
--- a/php/providers/AutocompleteProvider.php
+++ b/php/providers/AutocompleteProvider.php
@@ -43,8 +43,17 @@ class AutocompleteProvider extends Tools implements ProviderInterface
         }
 
         $returnValue = $values['args']['return'];
-        if ($returnValue == '$this' || $returnValue == 'self' || $returnValue == 'static') {
+        if ($returnValue == '$this' || $returnValue == 'static') {
             return $data;
+        } elseif ($returnValue === 'self') {
+            // Is the method returning self declared in the class itself or in a parent class? Self refers to the class
+            // declaring the method and will not point to child classes on inheritance, unless they redefine the method
+            // and its docblock.
+            if ($values['declaringClass'] === $class) {
+                return $data;
+            } else {
+                return $this->getClassMetadata($values['declaringClass']);
+            }
         } elseif (ucfirst($returnValue) === $returnValue) {
             $parser = new FileParser($classMap[$class]);
 


### PR DESCRIPTION
Hello

This fixes `self` being treated the same way as `$this` and `static` when autocompleting, while it is actually the same as mentioning the class name explicitly, for example:

```
class A
{
    /**
     * @return A
     */
    public function foo1() {}

    /**
     * @return self
     */
    public function foo2() {}

    /**
     * @return self
     */
    public function foo3() {}
}

class B extends A
{
    /**
     * @return self
     */
    public function foo3() {}
}

$b = new B();
$b->foo1(); // Returns instance of A, as indicated by docblock.
$b->foo2(); // Returns instance of A, as self refers to the name of the class declaring the method.
$b->foo3(); // Returns instance of B, as the method and its docblock was overriden in the child class and self now refers to B.
```

`static` or `$this` can be used in these cases to let `foo2` resolve to `B` instead of `A`.