### PR TITLE
Bugfix - Fix tooltips and go-to failing when mixing static and contextual method access.

### DIFF
--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -79,6 +79,10 @@ class AbstractGoto
         if editor.getGrammar().scopeName.match /text.html.php$/
             position = editor.getCursorBufferPosition()
             term = @parser.getFullWordFromBufferPosition(editor, position)
+
+            termParts = term.split(/(?:\-\>|::)/)
+            term = termParts.pop().replace('(', '')
+
             @gotoFromWord(editor, term)
 
     ###*
@@ -203,27 +207,25 @@ class AbstractGoto
     getJumpToRegex: (term) ->
 
     ###*
-     * Retrieves the called class and the splitter used.
+     * Retrieves the class the specified term (method or property) is being invoked on.
+     *
      * @param  {TextEditor} editor         TextEditor to search for namespace of term.
      * @param  {string}     term           Term to search for.
      * @param  {Point}      bufferPosition The cursor location the term is at.
+     *
+     * @return {string}
+     *
+     * @example Invoking it on MyMethod::foo()->bar() will ask what class 'bar' is invoked on, which will whatever type
+     *          foo returns.
     ###
-    getCalledClassInfo: (editor, term, bufferPosition) ->
+    getCalledClass: (editor, term, bufferPosition) ->
         proxy = require '../services/php-proxy.coffee'
         fullCall = @parser.getStackClasses(editor, bufferPosition)
 
         if fullCall.length == 0 or !term
           return
 
-        calledClass = ''
-        splitter = '->'
-
-        calledClass = @parser.parseElements(editor, bufferPosition, fullCall)
-
-        return {
-            calledClass : calledClass,
-            splitter    : splitter
-        }
+        return @parser.parseElements(editor, bufferPosition, fullCall)
 
     ###*
      * Jumps to a word within the editor

--- a/lib/goto/abstract-goto.coffee
+++ b/lib/goto/abstract-goto.coffee
@@ -217,15 +217,8 @@ class AbstractGoto
 
         calledClass = ''
         splitter = '->'
-        if fullCall.length > 1
-            calledClass = @parser.parseElements(editor, bufferPosition, fullCall)
-        else
-            parts = fullCall[0].trim().split('::')
-            splitter = '::'
-            if parts[0] == 'parent'
-                calledClass = @parser.getParentClass(editor)
-            else
-                calledClass = @parser.findUseForClass(editor, parts[0])
+
+        calledClass = @parser.parseElements(editor, bufferPosition, fullCall)
 
         return {
             calledClass : calledClass,

--- a/lib/goto/function-goto.coffee
+++ b/lib/goto/function-goto.coffee
@@ -21,23 +21,18 @@ class GotoFunction extends AbstractGoto
     gotoFromWord: (editor, term) ->
         bufferPosition = editor.getCursorBufferPosition()
 
-        calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+        calledClass = @getCalledClass(editor, term, bufferPosition)
 
-        if not calledClassInfo?.calledClass
+        if not calledClass
             return
-
-        calledClass = calledClassInfo.calledClass
-        splitter = calledClassInfo.splitter
 
         currentClass = @parser.getCurrentClass(editor, bufferPosition)
 
-        termParts = term.split(splitter)
-        term = termParts.pop().replace('(', '')
         if currentClass == calledClass && @jumpTo(editor, term)
             @manager.addBackTrack(editor.getPath(), bufferPosition)
             return
 
-        value = @getMethodForTerm(editor, term, bufferPosition, calledClassInfo)
+        value = @getMethodForTerm(editor, term, bufferPosition, calledClass)
 
         if not value
             return
@@ -154,20 +149,14 @@ class GotoFunction extends AbstractGoto
      * @param  {TextEditor} editor          TextEditor to search for namespace of term.
      * @param  {string}     term            Term to search for.
      * @param  {Point}      bufferPosition  The cursor location the term is at.
-     * @param  {Object}     calledClassInfo Information about the called class (optional).
+     * @param  {Object}     calledClass     Information about the called class (optional).
     ###
-    getMethodForTerm: (editor, term, bufferPosition, calledClassInfo) ->
-        if not calledClassInfo
-            calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+    getMethodForTerm: (editor, term, bufferPosition, calledClass) ->
+        if not calledClass
+            calledClass = @getCalledClass(editor, term, bufferPosition)
 
-        if not calledClassInfo?.calledClass
+        if not calledClass
             return
-
-        calledClass = calledClassInfo.calledClass
-        splitter = calledClassInfo.splitter
-
-        termParts = term.split(splitter)
-        term = termParts.pop().replace('(', '')
 
         proxy = require '../services/php-proxy.coffee'
         methods = proxy.methods(calledClass)
@@ -212,10 +201,7 @@ class GotoFunction extends AbstractGoto
 
                 term = match[2]
 
-                value = @getMethodForTerm(editor, term, null, {
-                    calledClass: currentClass,
-                    splitter: '->'
-                })
+                value = @getMethodForTerm(editor, term, null, currentClass)
 
                 if not value
                     continue

--- a/lib/goto/property-goto.coffee
+++ b/lib/goto/property-goto.coffee
@@ -16,23 +16,18 @@ class GotoProperty extends AbstractGoto
     gotoFromWord: (editor, term) ->
         bufferPosition = editor.getCursorBufferPosition()
 
-        calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+        calledClass = @getCalledClass(editor, term, bufferPosition)
 
-        if not calledClassInfo?.calledClass
+        if not calledClass
             return
-
-        calledClass = calledClassInfo.calledClass
-        splitter = calledClassInfo.splitter
 
         currentClass = @parser.getCurrentClass(editor, bufferPosition)
 
-        termParts = term.split(splitter)
-        term = termParts.pop()
         if currentClass == calledClass && @jumpTo(editor, term)
             @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
             return
 
-        value = @getPropertyForTerm(editor, term, bufferPosition, calledClassInfo)
+        value = @getPropertyForTerm(editor, term, bufferPosition, calledClass)
 
         if not value
             return
@@ -90,16 +85,14 @@ class GotoProperty extends AbstractGoto
      * @param  {TextEditor} editor          TextEditor to search for namespace of term.
      * @param  {string}     term            Term to search for.
      * @param  {Point}      bufferPosition  The cursor location the term is at.
-     * @param  {Object}     calledClassInfo Information about the called class (optional).
+     * @param  {Object}     calledClass     Information about the called class (optional).
     ###
-    getPropertyForTerm: (editor, term, bufferPosition, calledClassInfo) ->
-        if not calledClassInfo
-            calledClassInfo = @getCalledClassInfo(editor, term, bufferPosition)
+    getPropertyForTerm: (editor, term, bufferPosition, calledClass) ->
+        if not calledClass
+            calledClass = @getCalledClass(editor, term, bufferPosition)
 
-        if not calledClassInfo?.calledClass
+        if not calledClass
             return
-
-        calledClass = calledClassInfo.calledClass
 
         proxy = require '../services/php-proxy.coffee'
         methodsAndProperties = proxy.methods(calledClass)

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -346,7 +346,8 @@ module.exports =
     # Get the full text
     return [] if not text
 
-    elements = text.split("->")
+    elements = text.split(/(?:\-\>|::)/)
+    # elements = text.split("->")
 
     # Remove parenthesis and whitespaces
     for key, element of elements
@@ -470,13 +471,23 @@ module.exports =
     for element in elements
       # $this keyword
       if loop_index == 0
-        if element == '$this'
-
+        if element == '$this' or element == 'static' or element == 'self'
           className = @getCurrentClass(editor, bufferPosition)
           loop_index++
           continue
-        else
+
+        else if element[0] == '$'
           className = @getVariableType(editor, bufferPosition, element)
+          loop_index++
+          continue
+
+        else if element == 'parent'
+          className = @getParentClass(editor)
+          loop_index++
+          continue
+
+        else
+          className = @findUseForClass(editor, element)
           loop_index++
           continue
 


### PR DESCRIPTION
Hello

This started as a solution for mixing static method access followed by non-static method access causing tooltips and go-to to fail. For example:

```
Foo::bar()->someMethod();
```

No tooltips would show up for `someMethod` nor would go-to work properly. As a side effect this also seems to fix alt-clicking and tooltips on methods invoked using `self` and `static`.

When going through the code to fix these issues, I ran into some oddities and things that seemed to be performed without reason, such as spltting the term by `->` or `::` and then popping the last element off. It turns out these were only needed when performing go-to with the keyboard, so I moved these to be performed only for the keyboard go-to, which allowed to simplify a lot of the code.

If you notice anything that I refactored incorrectly, please let me know.

Hope this helps.