### PR TITLE
Tools - Ticket #86 - Support (incorrect) use of inheritDoc.

### DIFF
--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -96,6 +96,14 @@ abstract class Tools
 
         $docblockInheritsLongDescription = false;
 
+        // Ticket #86 - Add support for inheriting the entire docblock from the parent if the current docblock contains
+        // nothing but these tags. Note that, according to draft PSR-5 and phpDocumentor's implementation, this is
+        // incorrect. However, some large frameworks (such as Symfony) use this and it thus makes life easier for many
+        // developers, hence this workaround.
+        if (in_array($docParseResult['descriptions']['short'], array('{@inheritdoc}', '{@inheritDoc}'))) {
+            $docComment = false; // Pretend there is no docblock.
+        }
+
         if (strpos($docParseResult['descriptions']['long'], DocParser::INHERITDOC) !== false) {
             // The parent docblock is embedded, which we'll need to parse. Note that according to phpDocumentor this
             // only works for the long description (not the so-called 'summary' or short description).


### PR DESCRIPTION
Hello

As mentioned in ticket #86, some large frameworks such as Symfony use inheritDoc incorrectly. Because it would be a major convenience for those using these frameworks, I added a leniency to the docblock parsing that pretends no docblock is present when it only consists of the single `{@inheritDoc}` or `{@inheritdoc}`.