### PR TITLE
Bugfix - Create a custom tooltip popover.

### DIFF
--- a/lib/goto/class-provider.coffee
+++ b/lib/goto/class-provider.coffee
@@ -94,16 +94,6 @@ class ClassProvider extends AbstractProvider
                 @selectView.show()
 
     ###*
-     * Retrieves a tooltip for the word given.
-     *
-     * @param {TextEditor} editor         TextEditor to search for namespace of term.
-     * @param {string}     term           Term to search for.
-     * @param {Point}      bufferPosition The cursor location the term is at.
-    ###
-    getTooltipForWord: (editor, term, bufferPosition) ->
-        # TODO: Not implemented yet (as summaries from class docblocks are not extracted).
-
-    ###*
      * Gets the correct selector when a class or namespace is clicked.
      *
      * @param  {jQuery.Event}  event  A jQuery event.

--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -16,7 +16,10 @@ class AbstractProvider
 
         @subAtom = new SubAtom
 
-        # Find or create the tooltip popover.
+        # Find or create the tooltip popover. NOTE: The reason we do not use Atom's native tooltip is because it is
+        # attached to an element, which caused strange problems such as #107 and #72. This implementation uses the same
+        # CSS classes and transitions but handles the displaying manually as we don't want to attach/detach, we only
+        # want to temporarily display a popover on mouseover.
         @popover = @$(document.body).find('#php-atom-autocomplete-popover')
 
         if @popover?.length == 0

--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -17,11 +17,14 @@ class AbstractProvider
         @subAtom = new SubAtom
 
         # Find or create the tooltip popover.
-        @popover = @$(document.body).find('.php-atom-autocomplete-popover')
+        @popover = @$(document.body).find('#php-atom-autocomplete-popover')
 
         if @popover?.length == 0
-            @popover = document.createElement('span')
-            @popover.className = 'php-atom-autocomplete-popover'
+            @popover = document.createElement('div')
+            @popover.id = 'php-atom-autocomplete-popover'
+            @popover.className = 'tooltip bottom fade'
+            @popover.innerHTML = "<div class='tooltip-arrow'></div><div class='tooltip-inner'></div>"
+
             document.body.appendChild(@popover)
 
         atom.workspace.observeTextEditors (editor) =>
@@ -83,7 +86,8 @@ class AbstractProvider
 
             @subAtom.add scrollViewElement, 'mouseout', @hoverEventSelectors, (event) =>
                 clearTimeout(@timeout)
-                @$(@popover).hide();
+
+                @hideTooltip()
 
     ###*
      * Shows a tooltip containing the documentation of the specified element located at the specified location.
@@ -102,12 +106,22 @@ class AbstractProvider
 
             centerOffset = ((coordinates.right - coordinates.left) / 2)
 
-            @$(@popover).html('<div class="wrapper">' + tooltipText.replace(/\n/g, '<br/>') + '</div>')
+            @$('.tooltip-inner', @popover).html(
+                '<div class="php-atom-autocomplete-tooltip-wrapper">' + tooltipText.replace(/\n/g, '<br/>') + '</div>'
+            )
 
-            @$(@popover).css('left', (coordinates.left - (@$(@popover).width() / 8) + centerOffset) + 'px')
-            @$(@popover).css('top', (coordinates.bottom + 10) + 'px')
+            @$(@popover).css('left', (coordinates.left - (@$(@popover).width() / 2) + centerOffset) + 'px')
+            @$(@popover).css('top', (coordinates.bottom) + 'px')
 
-            @$(@popover).fadeIn(fadeInTime)
+            @$(@popover).addClass('in')
+            @$(@popover).css('opacity', 100)
+
+    ###*
+     * Hides the tooltip, if it is displayed.
+    ###
+    hideTooltip: () ->
+        @$(@popover).removeClass('in')
+        @$(@popover).css('opacity', 0)
 
     ###*
      * Retrieves a tooltip for the word given.

--- a/lib/tooltip/function-provider.coffee
+++ b/lib/tooltip/function-provider.coffee
@@ -75,7 +75,7 @@ class FunctionProvider extends AbstractProvider
 
         for param in value.args.optionals
             parametersDescription += "<div>"
-            parametersDescription += "• <strong>" + param + "</strong>"
+            parametersDescription += "• <strong>[" + param + "]</strong>"
             parametersDescription += "</div>"
 
         if value.args.parameters.length > 0 or value.args.optionals.length > 0

--- a/lib/tooltip/function-provider.coffee
+++ b/lib/tooltip/function-provider.coffee
@@ -35,8 +35,6 @@ class FunctionProvider extends AbstractProvider
         else
             accessModifier = 'private'
 
-        description += '<div style="margin-top: -1em; margin-bottom: -1em;">'
-
         description += "<p><div>"
         description += accessModifier + ' ' + returnType + ' <strong>' + term + '</strong>' + '('
 
@@ -62,10 +60,10 @@ class FunctionProvider extends AbstractProvider
 
         # Show the (long) description.
         if value.args.descriptions.long?.length > 0
-            description += "<p>"
-            description +=     "<div>Description:</div>"
-            description +=     "<div style='padding-left: 1em;'>" + value.args.descriptions.long + "</div>"
-            description += "</p>"
+            description += '<div class="section">'
+            description +=     "<h4>Description</h4>"
+            description +=     "<div>" + value.args.descriptions.long + "</div>"
+            description += "</div>"
 
         # Show the parameters the method has.
         parametersDescription = ""
@@ -81,16 +79,16 @@ class FunctionProvider extends AbstractProvider
             parametersDescription += "</div>"
 
         if value.args.parameters.length > 0 or value.args.optionals.length > 0
-            description += "<p>"
-            description +=     "<div>Parameters:</div>"
-            description +=     "<div style='padding-left: 1em;'>" + parametersDescription + "</div>"
-            description += "</p>"
+            description += '<div class="section">'
+            description +=     "<h4>Parameters</h4>"
+            description +=     "<div>" + parametersDescription + "</div>"
+            description += "</div>"
 
         if value.args.return
-            description += "<p>"
-            description +=     "<div>Returns:</div>"
-            description +=     "<div style='padding-left: 1em;'>" + value.args.return + "</div>"
-            description += "</p>"
+            description += '<div class="section">'
+            description +=     "<h4>Returns</h4>"
+            description +=     "<div>" + value.args.return + "</div>"
+            description += "</div>"
 
         # Show an overview of the exceptions the method can throw.
         throwsDescription = ""
@@ -105,11 +103,9 @@ class FunctionProvider extends AbstractProvider
             throwsDescription += "</div>"
 
         if throwsDescription.length > 0
-            description += "<p>"
-            description +=     "<div>Throws:</div>"
-            description +=     "<div style='margin-left: 1em;'>" + throwsDescription + "</div>"
-            description += "</p>"
-
-        description += "</div>"
+            description += '<div class="section">'
+            description +=     "<h4>Throws</h4>"
+            description +=     "<div>" + throwsDescription + "</div>"
+            description += "</div>"
 
         return description

--- a/lib/tooltip/function-provider.coffee
+++ b/lib/tooltip/function-provider.coffee
@@ -54,9 +54,9 @@ class FunctionProvider extends AbstractProvider
         description += '</div></p>'
 
         # Show the summary (short description).
-        description += '<p><div>'
+        description += '<div>'
         description +=     (if value.args.descriptions.short then value.args.descriptions.short else '(No documentation available)')
-        description += '</p></div>'
+        description += '</div>'
 
         # Show the (long) description.
         if value.args.descriptions.long?.length > 0

--- a/lib/tooltip/property-provider.coffee
+++ b/lib/tooltip/property-provider.coffee
@@ -33,7 +33,6 @@ class PropertyProvider extends AbstractProvider
 
         # Create a useful description to show in the tooltip.
         description = ''
-        description += '<div style="margin-top: -1em; margin-bottom: -1em;">'
 
         description += "<p><div>"
         description += accessModifier + ' ' + returnType + '<strong>' + ' $' + term + '</strong>'
@@ -46,11 +45,15 @@ class PropertyProvider extends AbstractProvider
 
         # Show the (long) description.
         if value.args.descriptions.long?.length > 0
-            description += "<p>"
-            description +=     "<div>Description:</div>"
-            description +=     "<div style='padding-left: 1em;'>" + value.args.descriptions.long + "</div>"
-            description += "</p>"
+            description += '<div class="section">'
+            description +=     "<h4>Description</h4>"
+            description +=     "<div>" + value.args.descriptions.long + "</div>"
+            description += "</div>"
 
-        description += "</div>"
+        if value.args.return
+            description += '<div class="section">'
+            description +=     "<h4>Type</h4>"
+            description +=     "<div>" + value.args.return + "</div>"
+            description += "</div>"
 
         return description

--- a/lib/tooltip/property-provider.coffee
+++ b/lib/tooltip/property-provider.coffee
@@ -39,9 +39,9 @@ class PropertyProvider extends AbstractProvider
         description += '</div></p>'
 
         # Show the summary (short description).
-        description += '<p><div>'
+        description += '<div>'
         description +=     (if value.args.descriptions.short then value.args.descriptions.short else '(No documentation available)')
-        description += '</p></div>'
+        description += '</div>'
 
         # Show the (long) description.
         if value.args.descriptions.long?.length > 0

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -17,6 +17,49 @@
     margin-left: -50%;
 }
 
+.php-atom-autocomplete-popover {
+    display: none;
+    z-index: 999999;
+    position: absolute;
+    text-align: left;
+    font-size: small;
+    opacity: 0.95;
+    color: @text-color-highlight;
+    background: @tool-panel-background-color;
+    border: 4px solid darken(@tool-panel-background-color, 1%);
+    border-radius: 5px;
+
+    .wrapper {
+        padding: 0em 1em 1em 1em;
+
+        .section {
+            > h4 {
+                margin-top: 1em;
+                font-size: larger;
+                font-weight: bold;
+            }
+
+            > div {
+                padding-left: 1em;
+            }
+        }
+
+    }
+}
+
+.php-atom-autocomplete-popover:before {
+    content: "";
+    position: absolute;
+    width: 0;
+    height: 0;
+    opacity: 0.95;
+    border-width: 5px;
+    border-style: solid;
+    border-color: transparent transparent darken(@tool-panel-background-color, 1%) transparent;
+    top: -14px;
+    left: 12.5%;
+}
+
 atom-text-editor, atom-text-editor::shadow {
     .comment-clickable .region {
         pointer-events: all;

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -17,47 +17,22 @@
     margin-left: -50%;
 }
 
-.php-atom-autocomplete-popover {
-    display: none;
-    z-index: 999999;
-    position: absolute;
+.php-atom-autocomplete-tooltip-wrapper {
+    margin: -1em 0em 0em 0em;
     text-align: left;
-    font-size: small;
-    opacity: 0.95;
-    color: @text-color-highlight;
-    background: @tool-panel-background-color;
-    border: 4px solid darken(@tool-panel-background-color, 1%);
-    border-radius: 5px;
 
-    .wrapper {
-        padding: 0em 1em 1em 1em;
-
-        .section {
-            > h4 {
-                margin-top: 1em;
-                font-size: larger;
-                font-weight: bold;
-            }
-
-            > div {
-                padding-left: 1em;
-            }
+    .section {
+        > h4 {
+            margin-top: 1em;
+            font-size: larger;
+            font-weight: bold;
         }
 
+        > div {
+            padding-left: 1em;
+        }
     }
-}
 
-.php-atom-autocomplete-popover:before {
-    content: "";
-    position: absolute;
-    width: 0;
-    height: 0;
-    opacity: 0.95;
-    border-width: 5px;
-    border-style: solid;
-    border-color: transparent transparent darken(@tool-panel-background-color, 1%) transparent;
-    top: -14px;
-    left: 12.5%;
 }
 
 atom-text-editor, atom-text-editor::shadow {


### PR DESCRIPTION
Hello

Seeing as it turns out I've been abusing Atom's tooltips and there is no actual popover implementation available in Atom (yet), I've replaced them with a custom simple popover.

I really didn't want to have to create a custom implementation for this, but it seems, for the moment, we have little choice (that is at least if we want to see these issues resolved). Note the following things:
  * The popover does not try to intelligently place itself somewhere in the editor. It just puts the arrow in the center of the word and is displayed about 12.5% of the width of the tooltip. Very very wide popovers may very well fall off the screen. Popovers will also not position themselves above the word if there is no space at the bottom (but I believe that currently doesn't happen either with our use of Atom's tooltips).
  * I used colors from the Styleguide to style the popover. It looks fine with my color scheme, but it may not in yours or someone else's color scheme. Advice on what colors to use instead is appreciated. I can use colors that look like the original tooltip Atom uses instead, but in my color scheme they are a pretty blinding white on blue, which doesn't really work for large amounts of text such as we have.

On a more positive note, the issues #107 en #72 seem to be resolved with this implementation. This also seems to fix an issue where sometimes tooltips would show up when hovering over entirely different code. The content of popovers are now styled through the stylesheet with classes, instead of manually injecting styling in the code.

Feedback is appreciated.