### PR TITLE
Bugfix - Fixed relative class names in docblocks not being treated entirely correctly.

### DIFF
--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -66,7 +66,7 @@ module.exports =
   getCalledClass: (editor, term, bufferPosition) ->
     fullCall = @getStackClasses(editor, bufferPosition)
 
-    if fullCall.length == 0 or !term
+    if fullCall?.length == 0 or !term
       return
 
     return @parseElements(editor, bufferPosition, fullCall)

--- a/php/services/FileParser.php
+++ b/php/services/FileParser.php
@@ -37,10 +37,6 @@ class FileParser
 
         $fullClass = $className;
 
-        if (count(explode('\\', $className)) > 1) {
-            return $className;
-        }
-
         while (!feof($this->file)) {
             $line = fgets($this->file);
 


### PR DESCRIPTION
Hello

This fixes an issue where class names in docblocks such as `Foo\Bar`, if they were relative, would not be detected correctly. This was because `getCompleteNamespace` assumed that if a class name contained multiple slashes, it must be absolute. It turned out this was a little more tricky to fix than it seemed at first sight as there are the following cases:
  * `\Foo\Bar` is always absolute, nothing needs to be done here.
  * `Foo\Bar` could refer to `\Foo\Bar` if composer.json is configured as such.
  * `Foo\Bar` could refer to e.g. `My\Foo\Bar` if the current namespace is `My`.

This pull request does the following things to `AutocompleteProvider::execute`:
  * I think (please correct me if I'm wrong) that `FileParser` should not be opened on the class the method is requested in. Instead it should be opened on the file that is declaring the method. This means that if a parent class declared the method, the code should assume the class name is relative to the parent class' namespace (or parse use statements there). Otherwise it could select the wrong class if there happened to be a class with the same name under the current namespace (or one that matches a use statement in the current class' file).
  * For absolute class names prefixed with a leading slash `\`, where there is no doubt about what class it is, it skips the need for the use of `FileParser`, optimizing the code a bit.
  * For class names without a leading slash `\`, it searches for a class relative to the namespace of the class where the method was declared. If it doesn't find one, it assumes that it must be an absolute class name without a leading slash (as configured with composer).

For an example, see also `testParentImports` in my test repository [1].

Feedback is appreciated.

[1] https://github.com/hotoiledgoblinsack/php-autocomplete-test/blob/17f181a4ec2474680c118fc8f7b5536f2270edeb/src/TestNamespace/SomeClass.php#L218