### PR TITLE
Bugfix - Fix imports by use statements no longer working due to my refactoring.

### DIFF
--- a/php/providers/AutocompleteProvider.php
+++ b/php/providers/AutocompleteProvider.php
@@ -5,83 +5,107 @@ namespace Peekmo\AtomAutocompletePhp;
 class AutocompleteProvider extends Tools implements ProviderInterface
 {
     /**
-     * Execute the command
-     * @param  array  $args Arguments gived to the command
+     * Execute the command.
+     *
+     * @param  array $args Arguments gived to the command.
+     *
      * @return array Response
      */
     public function execute($args = array())
     {
         $class = $args[0];
         $name  = $args[1];
-        $isMethod = false;
+
         if (strpos($class, '\\') === 0) {
             $class = substr($class, 1);
         }
-        if (strpos($name, '()') > -1) {
+
+        $isMethod = false;
+
+        if (strpos($name, '()') !== false) {
             $isMethod = true;
             $name = str_replace('()', '', $name);
         }
 
-        $classMap = $this->getClassMap();
+        $relevantClass = null;
         $data = $this->getClassMetadata($class);
-        if (!isset($data['values'][$name]) || !isset($classMap[$class])) {
-            return array(
-                'class'  => null,
-                'names'  => array(),
-                'values' => array()
-            );
-        }
-        $values = $data['values'][$name];
-        if (!isset($data['values'][$name]['isMethod'])) {
-            foreach ($data['values'][$name] as $value) {
-                if ($value['isMethod'] && $isMethod) {
-                    $values = $value;
-                } elseif (!$value['isMethod'] && !$isMethod) {
-                    $values = $value;
-                }
-            }
-        }
 
-        $returnValue = $values['args']['return'];
-        if ($returnValue == '$this' || $returnValue == 'static') {
-            return $data;
-        } elseif ($returnValue === 'self') {
-            // Is the method returning self declared in the class itself or in a parent class? Self refers to the class
-            // declaring the method and will not point to child classes on inheritance, unless they redefine the method
-            // and its docblock.
-            if ($values['declaringClass'] === $class) {
-                return $data;
-            } else {
-                return $this->getClassMetadata($values['declaringClass']);
-            }
-        } elseif (ucfirst($returnValue) === $returnValue) {
-            // At this point, this could either be a class name relative to the current namespace or a full class
-            // name without a leading slash. For example, Foo\Bar could also be relative (e.g. My\Foo\Bar), in which
-            // case its absolute path is determined by the namespace and use statements of the file containing it.
-            $className = $returnValue;
+        if (isset($data['values'][$name])) {
+            $memberInfo = $data['values'][$name];
 
-            if (!empty($className) && $returnValue[0] !== "\\" && isset($classMap[$values['declaringClass']])) {
-                $parser = new FileParser($classMap[$values['declaringClass']]);
-
-                $useStatementFound = false;
-                $competedClassName = $parser->getCompleteNamespace($returnValue, $useStatementFound);
-
-                if (!$useStatementFound) {
-                    $isRelativeClass = true;
-
-                    // Try instantiating the class, e.g. My\Foo\Bar.
-                    try {
-                        $reflection = new \ReflectionClass($competedClassName);
-
-                        $className = $competedClassName;
-                    } catch (\Exception $e) {
-                        // The class, e.g. My\Foo\Bar, didn't exist. We can only assume its an absolute path, using a
-                        // namespace set up in composer.json, without a leading slash.
+            if (!isset($data['values'][$name]['isMethod'])) {
+                foreach ($data['values'][$name] as $value) {
+                    if ($value['isMethod'] && $isMethod) {
+                        $memberInfo = $value;
+                    } elseif (!$value['isMethod'] && !$isMethod) {
+                        $memberInfo = $value;
                     }
                 }
             }
 
-            return $this->getClassMetadata($className);
+            $returnValue = $memberInfo['args']['return'];
+
+            if ($returnValue == '$this' || $returnValue == 'static') {
+                return $data;
+            } elseif ($returnValue === 'self') {
+                // Is the method returning self declared in the class itself or in a parent class? Self refers to the
+                // class declaring the method and will not point to child classes on inheritance, unless they redefine
+                // the method and its docblock.
+                if ($memberInfo['declaringClass'] === $class) {
+                    return $data;
+                } else {
+                    return $this->getClassMetadata($memberInfo['declaringClass']);
+                }
+            } elseif (ucfirst($returnValue) === $returnValue) {
+                // At this point, this could either be a class name relative to the current namespace or a full class
+                // name without a leading slash. For example, Foo\Bar could also be relative (e.g. My\Foo\Bar), in which
+                // case its absolute path is determined by the namespace and use statements of the file containing it.
+                $relevantClass = $returnValue;
+
+                $filename = null;
+
+                try {
+                    $reflection = new \ReflectionClass($memberInfo['declaringClass']);
+
+                    $filename = $reflection->getFileName();
+                } catch (\Exception $e) {
+
+                }
+
+                if (!empty($returnValue) && $returnValue[0] !== "\\" && $filename) {
+                    $parser = new FileParser($filename);
+
+                    $useStatementFound = false;
+                    $completedClassName = $parser->getCompleteNamespace($returnValue, $useStatementFound);
+
+                    if ($useStatementFound) {
+                        $relevantClass = $completedClassName;
+                    } else {
+                        $isRelativeClass = true;
+
+                        // Try instantiating the class, e.g. My\Foo\Bar.
+                        try {
+                            $reflection = new \ReflectionClass($completedClassName);
+
+                            $relevantClass = $completedClassName;
+                        } catch (\Exception $e) {
+                            // The class, e.g. My\Foo\Bar, didn't exist. We can only assume its an absolute path, using a
+                            // namespace set up in composer.json, without a leading slash.
+                        }
+                    }
+                }
+            }
         }
+
+        if ($relevantClass) {
+            // Minor optimization to avoid fetching the same data twice.
+            return ($relevantClass === $class) ? $data : $this->getClassMetadata($relevantClass);
+        }
+
+        return array(
+            'class'  => null,
+            'names'  => array(),
+            'values' => array()
+        );
     }
 }

--- a/php/providers/AutocompleteProvider.php
+++ b/php/providers/AutocompleteProvider.php
@@ -46,16 +46,9 @@ class AutocompleteProvider extends Tools implements ProviderInterface
             $returnValue = $memberInfo['args']['return'];
 
             if ($returnValue == '$this' || $returnValue == 'static') {
-                return $data;
+                $relevantClass = $class;
             } elseif ($returnValue === 'self') {
-                // Is the method returning self declared in the class itself or in a parent class? Self refers to the
-                // class declaring the method and will not point to child classes on inheritance, unless they redefine
-                // the method and its docblock.
-                if ($memberInfo['declaringClass'] === $class) {
-                    return $data;
-                } else {
-                    return $this->getClassMetadata($memberInfo['declaringClass']);
-                }
+                $relevantClass = $memberInfo['declaringClass'];
             } elseif (ucfirst($returnValue) === $returnValue) {
                 // At this point, this could either be a class name relative to the current namespace or a full class
                 // name without a leading slash. For example, Foo\Bar could also be relative (e.g. My\Foo\Bar), in which


### PR DESCRIPTION
Hello

It turned out that, with my last pull request fixing imports, I broke imports by use statement (the one thing I didn't test, the irony ;-) due to simply having forgotten to handle the 'else' clause (i.e. when `useStatementFound` was true).

I also did some minor refactoring, improving clarity and making sure the provider always returns data, does not fetch the same class twice if unnecessary and loosening the restriction of the class having to be available in the class map. The latter I did because, as far as I can see, all the code here can cope with classes that aren't in the Composer classmap; if there is an unsupported file, it will simply silently fail, but in many cases it could still work, providing autocompletion for those classes as well. However, if this is something you don't want (or there are corner cases I didn't see), let me know.

Sorry to bother you with this again!