### PR TITLE
Bugfix - Properly hide and show tooltips again.

### DIFF
--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -118,6 +118,7 @@ class AbstractProvider
 
             @$(@popover).addClass('in')
             @$(@popover).css('opacity', 100)
+            @$(@popover).css('display', 'block')
 
     ###*
      * Hides the tooltip, if it is displayed.
@@ -125,7 +126,7 @@ class AbstractProvider
     hideTooltip: () ->
         @$(@popover).removeClass('in')
         @$(@popover).css('opacity', 0)
-        @$(@popover).css('left', -@$(@popover).width())
+        @$(@popover).css('display', 'none')
 
     ###*
      * Retrieves a tooltip for the word given.


### PR DESCRIPTION
Hello

As described in #132, I'm creating this pull request even though it's not really necessary anymore. However, since I broke it I should probably also fix it properly (as punishment ;-). 

(Also, you never know if, in the future, the z-index of the tree view for some reason would become lower than that of the text editor, causing the tooltip to catch input there.)