### PR TITLE
Enhancement - Also allow function-provider to work outside functions.

### DIFF
--- a/lib/providers/function-provider.coffee
+++ b/lib/providers/function-provider.coffee
@@ -12,15 +12,14 @@ module.exports =
 # Autocomplete for internal PHP functions
 class FunctionProvider extends AbstractProvider
     functions: []
-    functionOnly: true
 
     ###*
      * Get suggestions from the provider (@see provider-api)
      * @return array
     ###
     fetchSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
-        # "new" keyword or word starting with capital letter
-        @regex = /(?:[^\w\$_\>])([a-z_]+)(?![\w\$_\>])/g
+        # not preceded by a > (arrow operator), a $ (variable start), ...
+        @regex = /(?:(?:^|[^\w\$_\>]))([a-z_]+)(?![\w\$_\>])/g
 
         prefix = @getPrefix(editor, bufferPosition)
         return unless prefix.length


### PR DESCRIPTION
Hello

This lifts the `functionOnly` restriction on the function provider, allowing autocompletion of built-in PHP functions everywhere (they do not have any namespace or class dependencies anyway).

The modification to the regex is to also allow the start of the line as a valid prefix, otherwise a line without indentation will not trigger the autocompletion.