### PR TITLE
Enhancement - Allow autocompletion outside functions and improve support for type override annotations.

### DIFF
--- a/lib/providers/abstract-provider.coffee
+++ b/lib/providers/abstract-provider.coffee
@@ -2,6 +2,7 @@ parser = require "../services/php-file-parser.coffee"
 
 module.exports =
 
+# Abstract base class for autocompletion providers.
 class AbstractProvider
     regex: ''
     selector: '.source.php'

--- a/lib/providers/autocomplete-provider.coffee
+++ b/lib/providers/autocomplete-provider.coffee
@@ -8,8 +8,7 @@ AbstractProvider = require "./abstract-provider"
 
 module.exports =
 
-# Other autocompletions (Everything is here !!)
-# WORK IN PROGRESS
+# Autocompletion for members of variables such as after ->, ::.
 class AutocompleteProvider extends AbstractProvider
     methods: []
 

--- a/lib/providers/autocomplete-provider.coffee
+++ b/lib/providers/autocomplete-provider.coffee
@@ -12,7 +12,6 @@ module.exports =
 # WORK IN PROGRESS
 class AutocompleteProvider extends AbstractProvider
     methods: []
-    functionOnly: true
 
     ###*
      * Get suggestions from the provider (@see provider-api)

--- a/lib/providers/class-provider.coffee
+++ b/lib/providers/class-provider.coffee
@@ -8,7 +8,7 @@ AbstractProvider = require "./abstract-provider"
 
 module.exports =
 
-# Autocompletion for class names
+# Autocompletion for class names (e.g. after the new or use keyword).
 class ClassProvider extends AbstractProvider
     classes = []
     disableForSelector: '.source.php .string'

--- a/lib/providers/function-provider.coffee
+++ b/lib/providers/function-provider.coffee
@@ -9,7 +9,7 @@ config = require "../config.coffee"
 
 module.exports =
 
-# Autocomplete for internal PHP functions
+# Autocompletion for internal PHP functions.
 class FunctionProvider extends AbstractProvider
     functions: []
 

--- a/lib/providers/parent-provider.coffee
+++ b/lib/providers/parent-provider.coffee
@@ -7,7 +7,7 @@ AbstractProvider = require "./abstract-provider.coffee"
 
 module.exports =
 
-# Autocomplete for parent keyword
+# Autocomplete for members following the parent keyword.
 class ParentProvider extends AbstractProvider
     parent: []
     functionOnly: true

--- a/lib/providers/self-provider.coffee
+++ b/lib/providers/self-provider.coffee
@@ -6,9 +6,8 @@ parser = require "../services/php-file-parser.coffee"
 AbstractProvider = require "./abstract-provider.coffee"
 
 module.exports =
-    
-# Autocomplete for static methods and constants inside a class
-# (keyword self:: and static::)
+
+# Autocomplete for static members following the self and static keywords (e.g. self:: and static::).
 class SelfProvider extends AbstractProvider
     statics: []
     functionOnly: true

--- a/lib/providers/static-provider.coffee
+++ b/lib/providers/static-provider.coffee
@@ -10,7 +10,6 @@ module.exports =
 # Autocomplete for static methods and constants
 class StaticProvider extends AbstractProvider
     statics: []
-    functionOnly: true
 
     ###*
      * Get suggestions from the provider (@see provider-api)

--- a/lib/providers/static-provider.coffee
+++ b/lib/providers/static-provider.coffee
@@ -7,7 +7,7 @@ AbstractProvider = require "./abstract-provider.coffee"
 
 module.exports =
 
-# Autocomplete for static methods and constants
+# Autocomplete for static members following a class name (e.g. Foo::).
 class StaticProvider extends AbstractProvider
     statics: []
 

--- a/lib/providers/variable-provider.coffee
+++ b/lib/providers/variable-provider.coffee
@@ -9,7 +9,6 @@ module.exports =
 # (keyword $)
 class VariableProvider extends AbstractProvider
     variables: []
-    functionOnly: true
 
     ###*
      * Get suggestions from the provider (@see provider-api)

--- a/lib/providers/variable-provider.coffee
+++ b/lib/providers/variable-provider.coffee
@@ -5,8 +5,7 @@ AbstractProvider = require "./abstract-provider"
 
 module.exports =
 
-# Autocomplete for viariables in the current function
-# (keyword $)
+# Autocomplete for local variable names.
 class VariableProvider extends AbstractProvider
     variables: []
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -430,6 +430,7 @@ module.exports =
                     bestMatchRow = lineNumber
                     bestMatch = @findUseForClass(editor, matchesNew[1])
 
+            if not bestMatch
                 # Check for catch(XXX $xxx)
                 matchesCatch = regexCatch.exec(line)
 
@@ -437,6 +438,7 @@ module.exports =
                     bestMatchRow = lineNumber
                     bestMatch = @findUseForClass(editor, matchesCatch[1])
 
+            if not bestMatch
                 # Check for a variable assignment $x = ...
                 matches = regexElement.exec(line)
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -97,7 +97,7 @@ module.exports =
 
         if isInFunction
             matches.push "$this"
-            
+
         return matches
 
     ###*
@@ -582,13 +582,18 @@ module.exports =
         for element in elements
             # $this keyword
             if loop_index == 0
-                if element == '$this' or element == 'static' or element == 'self'
-                    className = @getCurrentClass(editor, bufferPosition)
+                if element[0] == '$'
+                    className = @getVariableType(editor, bufferPosition, element)
+
+                    # NOTE: The type of $this can also be overridden locally by a docblock.
+                    if element == '$this' and not className
+                        className = @getCurrentClass(editor, bufferPosition)
+
                     loop_index++
                     continue
 
-                else if element[0] == '$'
-                    className = @getVariableType(editor, bufferPosition, element)
+                else if element == 'static' or element == 'self'
+                    className = @getCurrentClass(editor, bufferPosition)
                     loop_index++
                     continue
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -451,11 +451,10 @@ module.exports =
                         row : lineNumber
                         column: bufferPosition.column
 
-                    className = @parseElements(editor, newPosition, elements)
-
-                    if className
-                        bestMatchRow = lineNumber
-                        bestMatch = className
+                    # NOTE: bestMatch could now be null, but this line is still the closest match. The fact that we
+                    # don't recognize the class name is irrelevant.
+                    bestMatchRow = lineNumber
+                    bestMatch = @parseElements(editor, newPosition, elements)
 
             chain = editor.scopeDescriptorForBufferPosition([lineNumber, line.length]).getScopeChain()
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -78,15 +78,26 @@ module.exports =
      * @param {Range}      bufferPosition Position of the current buffer
     ###
     getAllVariablesInFunction: (editor, bufferPosition) ->
-        return if not @isInFunction(editor, bufferPosition)
+        # return if not @isInFunction(editor, bufferPosition)
+        isInFunction = @isInFunction(editor, bufferPosition)
 
-        text = editor.getTextInBufferRange([@cache["functionPosition"], [bufferPosition.row, bufferPosition.column-1]])
+        startPosition = null
+
+        if isInFunction
+            startPosition = @cache['functionPosition']
+
+        else
+            startPosition = [0, 0]
+
+        text = editor.getTextInBufferRange([startPosition, [bufferPosition.row, bufferPosition.column-1]])
         regex = /(\$[a-zA-Z_]+)/g
 
         matches = text.match(regex)
         return [] if not matches?
 
-        matches.push "$this"
+        if isInFunction
+            matches.push "$this"
+            
         return matches
 
     ###*


### PR DESCRIPTION
Hello

This pull request contains the following improvements:
  * Autocompletion for variables now works outside of functions as well. This is useful for e.g. `require`-d files that still contain use statements or use absolute class paths.
  * Refactored `getVariableType`.
  * `getVariableType` will no longer assume `/** @var FooType $var */` is actually a `/** @var FooType */` that applies to the variable below it if the variable below it. (Before, it always assumed that it needed to override it, even if the variable below it was is not `$var`.)
  * `getVariableType` now supports PHPStorm's `/** @var Footype $var */` (and it also still supports IntelliJ's `/** @var $var FooType */`).
  * The longer type overrides that contain the name of the variable can now be anywhere in the function and will always be used as override instead of being ignored when e.g. an assignment was found.
  * The type of `$this` can now be overridden again, it always resolved to `getCurrentClass` before.

I also added some tests for these cases [1].

[1] https://github.com/hotoiledgoblinsack/php-autocomplete-test/blob/24664493aeb7af113994dd1e067f290977f5eb9d/src/TestNamespace/SomeClass.php#L411