### PR TITLE
Bugfix - Fixed the class provider alt-click selector being too greedy.

### DIFF
--- a/lib/goto/abstract-provider.coffee
+++ b/lib/goto/abstract-provider.coffee
@@ -103,10 +103,11 @@ class AbstractProvider
             scrollViewElement = @$(textEditorElement.shadowRoot).find('.scroll-view')
 
             @subAtom.add scrollViewElement, 'mousemove', @hoverEventSelectors, (event) =>
+                return unless event.altKey
+
                 selector = @getSelectorFromEvent(event)
 
-                if selector == null or event.altKey == false
-                    return
+                return unless selector
 
                 @$(selector).css('border-bottom', '1px solid ' + @$(selector).css('color'))
                 @$(selector).css('cursor', 'pointer')
@@ -114,10 +115,11 @@ class AbstractProvider
                 @isHovering = true
 
             @subAtom.add scrollViewElement, 'mouseout', @hoverEventSelectors, (event) =>
+                return unless @isHovering
+
                 selector = @getSelectorFromEvent(event)
 
-                if selector == null
-                    return
+                return unless selector
 
                 @$(selector).css('border-bottom', '')
                 @$(selector).css('cursor', '')
@@ -136,8 +138,7 @@ class AbstractProvider
 
             # This is needed to be able to alt-click class names inside comments (docblocks).
             editor.onDidChangeCursorPosition (event) =>
-                if @isHovering == false
-                    return
+                return unless @isHovering
 
                 markerProperties =
                     containsBufferPosition: event.newBufferPosition

--- a/lib/goto/class-provider.coffee
+++ b/lib/goto/class-provider.coffee
@@ -106,10 +106,14 @@ class ClassProvider extends AbstractProvider
         if @$(selector).hasClass('builtin') or @$(selector).children('.builtin').length > 0
             return null
 
-        if @$(selector).parent().hasClass('function argument') or
-           @$(selector).prev().hasClass('namespace') && @$(selector).hasClass('class') or
-           @$(selector).next().hasClass('class') && @$(selector).hasClass('namespace')
+        if @$(selector).parent().hasClass('function argument')
             return @$(selector).parent().children('.namespace, .class:not(.operator):not(.constant)')
+
+        if @$(selector).prev().hasClass('namespace') && @$(selector).hasClass('class')
+            return @$([@$(selector).prev()[0], selector])
+
+        if @$(selector).next().hasClass('class') && @$(selector).hasClass('namespace')
+           return @$([selector, @$(selector).next()[0]])
 
         if @$(selector).prev().hasClass('namespace') || @$(selector).next().hasClass('inherited-class')
             return @$(selector).parent().children('.namespace, .inherited-class')


### PR DESCRIPTION
Hello

The selector returned for class alt-click request all namespace and class children of the parent when a match is found, which is a little bit too greedy. Take the following example:

```php
$something->test('someString', function ($var) {
    return new TestNamespace\Foo\FooClass(new Bar\BarTrait());
               --------------------------     -------------
                        <Mouse>
});
```

When I hover over the first class, the second class also gets underlined, and, by consequence, the class goto fails. This was resolved by just returning the element hovered over and the previous and next elements that are part of it, not all the children matching the same selector.

