### PR TITLE
Tooltip - Hopefully fix issue #140.

### DIFF
--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -82,9 +82,13 @@ class AbstractProvider
 
                 # Try to show a tooltip containing the documentation of the item.
                 @timeout = setTimeout(() =>
-                    cursorPosition = atom.views.getView(editor).component.screenPositionForMouseEvent(event)
+                    editorViewComponent = atom.views.getView(editor).component
 
-                    @showTooltipFor(editor, selector, cursorPosition)
+                    # Ticket #140 - In rare cases the component is null.
+                    if editorViewComponent
+                        cursorPosition = editorViewComponent.screenPositionForMouseEvent(event)
+
+                        @showTooltipFor(editor, selector, cursorPosition)
                 , 500)
 
             @subAtom.add scrollViewElement, 'mouseout', @hoverEventSelectors, (event) =>


### PR DESCRIPTION
Hello

This hopefully resolves ticket #140. I've also had it happen a few times, but can't reliably reproduce it and don't know why it is happening. IIRC it recently appeared, but the `screenPositionForMouseEvent` was also used before the tooltip refactoring.