### PR TITLE
Bugfix - Refactor the indexing Tools, fixing several issues.

### DIFF
--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -107,11 +107,13 @@ class FunctionProvider extends AbstractProvider
 
                             tooltipText = ''
 
+                            # NOTE: We explicitly show the declaring class here, not the structure (which could be a
+                            # trait).
                             if value.override
-                                tooltipText += 'Overrides method from ' + value.override.declaringClass
+                                tooltipText += 'Overrides method from ' + value.override.declaringClass.name
 
                             else
-                                tooltipText += 'Implements method for ' + value.implementation.declaringClass
+                                tooltipText += 'Implements method for ' + value.implementation.declaringClass.name
 
                             atom.tooltips.add(event.target, {
                                 title: '<div style="text-align: left;">' + tooltipText + '</div>'

--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -39,14 +39,6 @@ class FunctionProvider extends AbstractProvider
         if not value
             return
 
-
-        ###
-        parentClass = value.declaringClass
-
-        proxy = require '../services/php-proxy.coffee'
-        classMap = proxy.autoloadClassMap()
-        ###
-
         atom.workspace.open(value.declaringStructure.filename, {
             initialLine    : (value.startLine - 1),
             searchAllPanes : true

--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -39,12 +39,15 @@ class FunctionProvider extends AbstractProvider
         if not value
             return
 
+
+        ###
         parentClass = value.declaringClass
 
         proxy = require '../services/php-proxy.coffee'
         classMap = proxy.autoloadClassMap()
+        ###
 
-        atom.workspace.open(classMap[parentClass], {
+        atom.workspace.open(value.declaringStructure.filename, {
             initialLine    : (value.startLine - 1),
             searchAllPanes : true
         })
@@ -113,10 +116,10 @@ class FunctionProvider extends AbstractProvider
                             tooltipText = ''
 
                             if value.override
-                                tooltipText += 'Overrides method from ' + value.override.baseClass
+                                tooltipText += 'Overrides method from ' + value.override.declaringClass
 
                             else
-                                tooltipText += 'Implements method from ' + value.implementation.interfaceName
+                                tooltipText += 'Implements method for ' + value.implementation.declaringClass
 
                             atom.tooltips.add(event.target, {
                                 title: '<div style="text-align: left;">' + tooltipText + '</div>'
@@ -127,21 +130,10 @@ class FunctionProvider extends AbstractProvider
                             })
 
                         @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'click', selector, (event) =>
-                            parentClass = value.declaringClass
+                            referencedObject = if value.override then value.override else value.implementation
 
-                            proxy = require '../services/php-proxy.coffee'
-                            classMap = proxy.autoloadClassMap()
-
-                            if value.override
-                                referencedClass = value.override.baseClass
-                                referencedLine = value.override.baseMethodStartLine
-
-                            else
-                                referencedClass = value.implementation.interfaceName
-                                referencedLine = value.implementation.interfaceMethodStartLine
-
-                            atom.workspace.open(classMap[referencedClass], {
-                                initialLine    : referencedLine - 1,
+                            atom.workspace.open(referencedObject.declaringStructure.filename, {
+                                initialLine    : referencedObject.startLine - 1,
                                 searchAllPanes : true
                             })
 

--- a/lib/goto/property-provider.coffee
+++ b/lib/goto/property-provider.coffee
@@ -34,14 +34,10 @@ class PropertyProvider extends AbstractProvider
         if not value
             return
 
-        parentClass = value.declaringClass
-
-        proxy = require '../services/php-proxy.coffee'
-        classMap = proxy.autoloadClassMap()
-
-        atom.workspace.open(classMap[parentClass], {
+        atom.workspace.open(value.declaringStructure.filename, {
             searchAllPanes: true
         })
+        
         @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
         @jumpWord = term
 

--- a/php/providers/AutocompleteProvider.php
+++ b/php/providers/AutocompleteProvider.php
@@ -55,18 +55,8 @@ class AutocompleteProvider extends Tools implements ProviderInterface
                 // case its absolute path is determined by the namespace and use statements of the file containing it.
                 $relevantClass = $returnValue;
 
-                $filename = null;
-
-                try {
-                    $reflection = new \ReflectionClass($memberInfo['declaringClass']);
-
-                    $filename = $reflection->getFileName();
-                } catch (\Exception $e) {
-
-                }
-
-                if (!empty($returnValue) && $returnValue[0] !== "\\" && $filename) {
-                    $parser = new FileParser($filename);
+                if (!empty($returnValue) && $returnValue[0] !== "\\") {
+                    $parser = new FileParser($memberInfo['declaringStructure']['filename']);
 
                     $useStatementFound = false;
                     $completedClassName = $parser->getCompleteNamespace($returnValue, $useStatementFound);

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -214,11 +214,13 @@ abstract class Tools
         // This will point to the class that contains the member, which will resolve to the parent class if it's
         // inherited (and not overridden).
         $declaringStructure = $reflectionMember->getDeclaringClass();
+        $isMethod = ($reflectionMember instanceof ReflectionFunctionAbstract);
 
         // Members from traits are seen as part of the structure using the trait, but we still want the actual trait
         // name.
         foreach ($declaringStructure->getTraits() as $trait) {
-            if ($trait->hasMethod($reflectionMember->name)) {
+            if (($isMethod && $trait->hasMethod($reflectionMember->name)) ||
+                (!$isMethod && $trait->hasProperty($reflectionMember->name))) {
                 $declaringStructure = $trait;
                 break;
             }

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -203,11 +203,30 @@ abstract class Tools
     }
 
     /**
+     * Retrieves the class that contains the specified reflection member.
+     *
+     * @param ReflectionFunctionAbstract|ReflectionProperty $reflectionMember
+     *
+     * @return array
+     */
+    protected function getDeclaringClass($reflectionMember)
+    {
+        // This will point to the class that contains the member, which will resolve to the parent class if it's
+        // inherited (and not overridden).
+        $declaringClass = $reflectionMember->getDeclaringClass();
+
+        return array(
+            'name'     => $declaringClass->name,
+            'filename' => $declaringClass->getFilename()
+        );
+    }
+
+    /**
      * Retrieves the structure (class, trait, interface, ...) that contains the specified reflection member.
      *
      * @param ReflectionFunctionAbstract|ReflectionProperty $reflectionMember
      *
-     * @return string
+     * @return array
      */
     protected function getDeclaringStructure($reflectionMember)
     {
@@ -264,7 +283,7 @@ abstract class Tools
         }
 
         return array(
-            'declaringClass'     => $overriddenMember->getDeclaringClass()->getName(),
+            'declaringClass'     => $this->getDeclaringClass($overriddenMember),
             'declaringStructure' => $this->getDeclaringStructure($overriddenMember),
             'startLine'          => $startLine
         );
@@ -294,7 +313,7 @@ abstract class Tools
         }
 
         return array(
-            'declaringClass'     => $implementedMember->getDeclaringClass()->getName(),
+            'declaringClass'     => $this->getDeclaringClass($implementedMember),
             'declaringStructure' => $this->getDeclaringStructure($implementedMember),
             'startLine'          => $implementedMember->getStartLine()
         );
@@ -339,7 +358,7 @@ abstract class Tools
                 'implementation'     => $this->getImplementationInfo($method),
 
                 'args'               => $this->getMethodArguments($method),
-                'declaringClass'     => $method->getDeclaringClass()->name,
+                'declaringClass'     => $this->getDeclaringClass($method),
                 'declaringStructure' => $this->getDeclaringStructure($method),
                 'startLine'          => $method->getStartLine()
             );
@@ -363,7 +382,7 @@ abstract class Tools
                 'override'           => $this->getOverrideInfo($attribute),
 
                 'args'               => $this->getPropertyArguments($attribute),
-                'declaringClass'     => $attribute->getDeclaringClass()->name,
+                'declaringClass'     => $this->getDeclaringClass($attribute),
                 'declaringStructure' => $this->getDeclaringStructure($attribute)
             );
 
@@ -395,7 +414,10 @@ abstract class Tools
                 'isProperty'     => false,
                 'isPublic'       => true,
                 'isProtected'    => false,
-                'declaringClass' => $reflection->name,
+                'declaringClass' => array(
+                    'name'     => $reflection->name,
+                    'filename' => $reflection->getFileName()
+                ),
 
                 // TODO: It is not possible to directly fetch the docblock of the constant through reflection, manual
                 // file parsing is required.

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -273,7 +273,23 @@ abstract class Tools
         }
 
         if (!$overriddenMember) {
-            return null;
+            // This method is not an override of a parent method, see if it is an 'override' of an abstract method from
+            // a trait the class it is in is using.
+            if ($reflectionMember instanceof ReflectionFunctionAbstract) {
+                foreach ($reflectionMember->getDeclaringClass()->getTraits() as $trait) {
+                    if ($trait->hasMethod($methodName)) {
+                        $traitMethod = $trait->getMethod($methodName);
+
+                        if ($traitMethod->isAbstract()) {
+                            $overriddenMember = $traitMethod;
+                        }
+                    }
+                }
+            }
+
+            if (!$overriddenMember) {
+                return null;
+            }
         }
 
         $startLine = null;

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -120,7 +120,7 @@ abstract class Tools
             $classIterator = new ReflectionClass($function->class);
             $classIterator = $classIterator->getParentClass();
 
-            // Check if this method is implemented an abstract method from a trait, in which case that docblock should
+            // Check if this method is implementing an abstract method from a trait, in which case that docblock should
             // be used.
             if (!$docComment) {
                 foreach ($function->getDeclaringClass()->getTraits() as $trait) {
@@ -129,6 +129,22 @@ abstract class Tools
 
                         if ($traitMethod->isAbstract() && $traitMethod->getDocComment()) {
                             return $this->getMethodArguments($traitMethod);
+                        }
+                    }
+                }
+            }
+
+            // Check if this method is implementing an interface method, in which case that docblock should be used.
+            // NOTE: If the parent class has an interface, getMethods() on the parent class will include the interface
+            // methods, along with their docblocks, even if the parent doesn't actually implement the method. So we only
+            // have to check the interfaces of the declaring class.
+            if (!$docComment) {
+                foreach ($function->getDeclaringClass()->getInterfaces() as $interface) {
+                    if ($interface->hasMethod($function->getName())) {
+                        $interfaceMethod = $interface->getMethod($function->getName());
+
+                        if ($interfaceMethod->getDocComment()) {
+                            return $this->getMethodArguments($interfaceMethod);
                         }
                     }
                 }


### PR DESCRIPTION
Hello

This refactors the `Tools` class again, fixing several issues and improving several things:
  * Use of the autoload class map has been made redundant in several parts of the code due to being able to fetch the filename through reflection. This removes the need to perform an extra PHP call in several locations. Go to seems to be a tad smoother now.
  * Determining the full class path based on use statements and the namespace in a file happened using the `declaringClass`, which was wrong if the method or property was actually located in a trait (in another file).
  * Go to and clicking annotations of members originating from traits now works properly, navigating to the member in the trait itself.
  * Fixes #98, #138 and #145.

On the technical side, there is now `declaringClass` and `declaringStructure`, the former is always the actual **class** containing the member, whilst the latter is more specific and will point to a trait if that is where the method is coming from. Both are useful and used in different situations.

PS: After this is merged, I think we're almost able to drop use of the autoload class map on the CoffeeScript side. The last use is in `class-provider`, but it could be replaced by just requesting info about the class name via reflection instead.