### PR TITLE
Enhancement - Skip a Composer class dump on incremental save.

### DIFF
--- a/php/providers/ClassMapRefresh.php
+++ b/php/providers/ClassMapRefresh.php
@@ -11,8 +11,6 @@ class ClassMapRefresh extends Tools implements ProviderInterface
      */
     public function execute($args = array())
     {
-        $classMap = $this->getClassMap(true);
-
         $fileExists = false;
 
         // If we specified a file
@@ -24,7 +22,12 @@ class ClassMapRefresh extends Tools implements ProviderInterface
                 if (false !== $index) {
                     $fileExists = true;
 
-                    if (false !== $class = array_search($file, $classMap)) {
+                    $found = false;
+                    $fileParser = new FileParser($file);
+                    $class = $fileParser->getCompleteNamespace(null, $found);
+
+                    // if (false !== $class = array_search($file, $classMap)) {
+                    if ($found) {
                         if (isset($index['mapping'][$class])) {
                             unset($index['mapping'][$class]);
                         }
@@ -46,7 +49,7 @@ class ClassMapRefresh extends Tools implements ProviderInterface
         // Otherwise, full index
         if (!$fileExists) {
             // Autoload classes
-            foreach ($classMap as $class => $filePath) {
+            foreach ($this->getClassMap(true) as $class => $filePath) {
                 if ($value = $this->buildIndexClass($class)) {
                     $index['mapping'][$class] = $value;
                     $index['autocomplete'][] = $class;

--- a/php/providers/DocParamProvider.php
+++ b/php/providers/DocParamProvider.php
@@ -18,8 +18,6 @@ class DocParamProvider extends Tools implements ProviderInterface
             $class = substr($class, 1);
         }
 
-        $classMap = $this->getClassMap();
-
         $parser = new DocParser();
         return $parser->get($class, 'method', $name, array(DocParser::PARAM_TYPE));
     }


### PR DESCRIPTION
Hello

This modifies `ClassMapRefresh` to only force a class map refresh when doing the full index. After that, it can just use `getCompleteNamespace` to retrieve the class in the modified file. This implements #118 and hopefully will make incremental indexing after the initial index much faster for large projects, as the bottleneck seems to be the composer class dump there.