### PR TITLE
Bugfix - member-provider is no longer able to cope with multiple lines.

### DIFF
--- a/lib/providers/member-provider.coffee
+++ b/lib/providers/member-provider.coffee
@@ -18,7 +18,7 @@ class MemberProvider extends AbstractProvider
     ###
     fetchSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
         # Autocompletion for class members, i.e. after a ::, ->, ...
-        @regex = /(?:(?:[a-zA-Z0-9_]+)(?:\(.*\))?(?:->|::))+([a-zA-Z0-9_]*)/g
+        @regex = /(?:(?:[a-zA-Z0-9_]*)\s*(?:\(.*\))?\s*(?:->|::)\s*)+([a-zA-Z0-9_]*)/g
 
         prefix = @getPrefix(editor, bufferPosition)
         return unless prefix.length


### PR DESCRIPTION
Hello

This fixes an issue with the member-provider regex where it could no longer cope with autocompletion over multiple lines, which is often used with the fluent interface (see also `testChaining` in my test repository).