### PR TITLE
Bugfix - Reapply a pull request that got lost.

### DIFF
--- a/lib/providers/member-provider.coffee
+++ b/lib/providers/member-provider.coffee
@@ -18,7 +18,7 @@ class MemberProvider extends AbstractProvider
     ###
     fetchSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
         # Autocompletion for class members, i.e. after a ::, ->, ...
-        @regex = /(?:(?:[a-zA-Z0-9_]+)(?:\(.*\))?(?:->|::))+([a-zA-Z0-9_]*)/g
+        @regex = /(?:(?:[a-zA-Z0-9_]*)\s*(?:\(.*\))?\s*(?:->|::)\s*)+([a-zA-Z0-9_]*)/g
 
         prefix = @getPrefix(editor, bufferPosition)
         return unless prefix.length


### PR DESCRIPTION
Hello

It appears the changes from pull request #160 got lost. I think this happened because I originally had these changes in pull request #159, but I reverted them there so I could split them off into a separate pull request because it didn't belong there. You merged #160 first and then #159 later, which probably caused the commit to get applied from #160, then applied again in #159 (which caused no changes) and then reverted by #159 (I cherry picked the change, causing it to use the same commit hash).