### PR TITLE
Bugfix - Ticket #156 - Refactor popover into two separate classes and fix annotation tooltips.

### DIFF
--- a/lib/services/attached-popover.coffee
+++ b/lib/services/attached-popover.coffee
@@ -52,11 +52,10 @@ class AttachedPopover extends Popover
      * Shows the popover with the specified text after the specified delay (in miliiseconds). Calling this method
      * multiple times will cancel previous show requests and restart.
      *
-     * @param {string} text       The text to display.
      * @param {int}    delay      The delay before the tooltip shows up (in milliseconds).
      * @param {int}    fadeInTime The amount of time to take to fade in the tooltip.
     ###
-    showAfter: (text, delay, fadeInTime = 100) ->
+    showAfter: (delay, fadeInTime = 100) ->
         @timeoutId = setTimeout(() =>
-            @show(text, fadeInTime)
+            @show(fadeInTime)
         , delay)

--- a/lib/services/attached-popover.coffee
+++ b/lib/services/attached-popover.coffee
@@ -1,17 +1,14 @@
-{Disposable} = require 'atom'
-
 Popover = require './popover'
 
 module.exports =
 
-class AttachedPopover extends Disposable
+class AttachedPopover extends Popover
     ###
         NOTE: The reason we do not use Atom's native tooltip is because it is attached to an element, which caused
         strange problems such as tickets #107 and #72. This implementation uses the same CSS classes and transitions but
         handles the displaying manually as we don't want to attach/detach, we only want to temporarily display a popover
         on mouseover.
     ###
-    popover: null
     timeoutId: null
     elementToAttachTo: null
 
@@ -23,11 +20,7 @@ class AttachedPopover extends Disposable
      *                                        up (in miliiseconds).
     ###
     constructor: (@elementToAttachTo, delay = 500) ->
-        @$ = require 'jquery'
-
-        @popover = new Popover()
-
-        super @destructor
+        super()
 
     ###*
      * Destructor.
@@ -38,15 +31,7 @@ class AttachedPopover extends Disposable
             clearTimeout(@timeoutId)
             @timeoutId = null
 
-        @popover.dispose()
-
-    ###*
-     * sets the text to display.
-     *
-     * @param {string} text
-    ###
-    setText: (text) ->
-        @popover.setText(text)
+        super()
 
     ###*
      * Shows the popover with the specified text.
@@ -58,10 +43,10 @@ class AttachedPopover extends Disposable
 
         centerOffset = ((coordinates.right - coordinates.left) / 2)
 
-        x = coordinates.left - (@$(@popover.getElement()).width() / 2) + centerOffset
+        x = coordinates.left - (@$(@getElement()).width() / 2) + centerOffset
         y = coordinates.bottom
 
-        @popover.show(x, y, fadeInTime)
+        super(x, y, fadeInTime)
 
     ###*
      * Shows the popover with the specified text after the specified delay (in miliiseconds). Calling this method
@@ -75,9 +60,3 @@ class AttachedPopover extends Disposable
         @timeoutId = setTimeout(() =>
             @show(text, fadeInTime)
         , delay)
-
-    ###*
-     * Hides the tooltip, if it is displayed.
-    ###
-    hide: () ->
-        @popover.hide()

--- a/lib/services/attached-popover.coffee
+++ b/lib/services/attached-popover.coffee
@@ -1,0 +1,76 @@
+{Disposable} = require 'atom'
+
+Popover = require './popover'
+
+module.exports =
+
+class AttachedPopover extends Disposable
+    ###
+        NOTE: The reason we do not use Atom's native tooltip is because it is attached to an element, which caused
+        strange problems such as tickets #107 and #72. This implementation uses the same CSS classes and transitions but
+        handles the displaying manually as we don't want to attach/detach, we only want to temporarily display a popover
+        on mouseover.
+    ###
+    popover: null
+    timeoutId: null
+    elementToAttachTo: null
+
+    ###*
+     * Constructor.
+     *
+     * @param {HTMLElement} elementToAttachTo The element to show the popover over.
+     * @param {int}         delay             How long the mouse has to hover over the elment before the popover shows
+     *                                        up (in miliiseconds).
+    ###
+    constructor: (@elementToAttachTo, delay = 500) ->
+        @$ = require 'jquery'
+        
+        @popover = new Popover()
+
+        super @destructor
+
+    ###*
+     * Destructor.
+     *
+    ###
+    destructor: () ->
+        if @timeoutId
+            clearTimeout(@timeoutId)
+            @timeoutId = null
+
+        @popover.dispose()
+
+    ###*
+     * Shows the popover with the specified text.
+     *
+     * @param {string} text       The text to display.
+     * @param {int}    fadeInTime The amount of time to take to fade in the tooltip.
+    ###
+    show: (text, fadeInTime = 100) ->
+        coordinates = @elementToAttachTo.getBoundingClientRect();
+
+        centerOffset = ((coordinates.right - coordinates.left) / 2)
+
+        x = coordinates.left - (@$(@popover.getElement()).width() / 2) + centerOffset
+        y = coordinates.bottom
+
+        @popover.show(text, x, y, fadeInTime)
+
+    ###*
+     * Shows the popover with the specified text after the specified delay (in miliiseconds). Calling this method
+     * multiple times will cancel previous show requests and restart.
+     *
+     * @param {string} text       The text to display.
+     * @param {int}    delay      The delay before the tooltip shows up (in milliseconds).
+     * @param {int}    fadeInTime The amount of time to take to fade in the tooltip.
+    ###
+    showAfter: (text, delay, fadeInTime = 100) ->
+        @timeoutId = setTimeout(() =>
+            @show(text, fadeInTime)
+        , delay)
+
+    ###*
+     * Hides the tooltip, if it is displayed.
+    ###
+    hide: () ->
+        @popover.hide()

--- a/lib/services/attached-popover.coffee
+++ b/lib/services/attached-popover.coffee
@@ -24,7 +24,7 @@ class AttachedPopover extends Disposable
     ###
     constructor: (@elementToAttachTo, delay = 500) ->
         @$ = require 'jquery'
-        
+
         @popover = new Popover()
 
         super @destructor
@@ -41,12 +41,19 @@ class AttachedPopover extends Disposable
         @popover.dispose()
 
     ###*
+     * sets the text to display.
+     *
+     * @param {string} text
+    ###
+    setText: (text) ->
+        @popover.setText(text)
+
+    ###*
      * Shows the popover with the specified text.
      *
-     * @param {string} text       The text to display.
-     * @param {int}    fadeInTime The amount of time to take to fade in the tooltip.
+     * @param {int} fadeInTime The amount of time to take to fade in the tooltip.
     ###
-    show: (text, fadeInTime = 100) ->
+    show: (fadeInTime = 100) ->
         coordinates = @elementToAttachTo.getBoundingClientRect();
 
         centerOffset = ((coordinates.right - coordinates.left) / 2)
@@ -54,7 +61,7 @@ class AttachedPopover extends Disposable
         x = coordinates.left - (@$(@popover.getElement()).width() / 2) + centerOffset
         y = coordinates.bottom
 
-        @popover.show(text, x, y, fadeInTime)
+        @popover.show(x, y, fadeInTime)
 
     ###*
      * Shows the popover with the specified text after the specified delay (in miliiseconds). Calling this method

--- a/lib/services/popover.coffee
+++ b/lib/services/popover.coffee
@@ -1,0 +1,68 @@
+{Disposable} = require 'atom'
+
+module.exports =
+
+class Popover extends Disposable
+    ###
+        NOTE: The reason we do not use Atom's native tooltip is because it is attached to an element, which caused
+        strange problems such as tickets #107 and #72. This implementation uses the same CSS classes and transitions but
+        handles the displaying manually as we don't want to attach/detach, we only want to temporarily display a popover
+        on mouseover.
+    ###
+    element: null
+    elementToAttachTo: null
+
+    ###*
+     * Constructor.
+     *
+     * @param {HTMLElement} elementToAttachTo The element to show the popover over.
+    ###
+    constructor: (@elementToAttachTo) ->
+        @$ = require 'jquery'
+
+        @element = document.createElement('div')
+        @element.id = 'php-atom-autocomplete-popover'
+        @element.className = 'tooltip bottom fade'
+        @element.innerHTML = "<div class='tooltip-arrow'></div><div class='tooltip-inner'></div>"
+
+        document.body.appendChild(@element)
+
+        super @destructor
+
+    ###*
+     * Destructor.
+     *
+    ###
+    destructor: () ->
+        @hide()
+        document.body.removeChild(@element)
+
+    ###*
+     * Shows a tooltip containing the documentation of the specified element located at the specified location.
+     *
+     * @param {string} text       The text to display.
+     * @param {int}    fadeInTime The amount of time to take to fade in the tooltip.
+    ###
+    show: (text, fadeInTime = 100) ->
+        coordinates = @elementToAttachTo.getBoundingClientRect();
+
+        centerOffset = ((coordinates.right - coordinates.left) / 2)
+
+        @$('.tooltip-inner', @element).html(
+            '<div class="php-atom-autocomplete-popover-wrapper">' + text.replace(/\n/g, '<br/>') + '</div>'
+        )
+
+        @$(@element).css('left', (coordinates.left - (@$(@element).width() / 2) + centerOffset) + 'px')
+        @$(@element).css('top', (coordinates.bottom) + 'px')
+
+        @$(@element).addClass('in')
+        @$(@element).css('opacity', 100)
+        @$(@element).css('display', 'block')
+
+    ###*
+     * Hides the tooltip, if it is displayed.
+    ###
+    hide: () ->
+        @$(@element).removeClass('in')
+        @$(@element).css('opacity', 0)
+        @$(@element).css('display', 'none')

--- a/lib/services/popover.coffee
+++ b/lib/services/popover.coffee
@@ -36,18 +36,23 @@ class Popover extends Disposable
         return @element
 
     ###*
-     * Shows a popover at the specified location with the specified text and fade in time.
+     * sets the text to display.
      *
-     * @param {string} text       The text to display.
-     * @param {int}    x          The X coordinate to show the popover at (left).
-     * @param {int}    y          The Y coordinate to show the popover at (top).
-     * @param {int}    fadeInTime The amount of time to take to fade in the tooltip.
+     * @param {string} text
     ###
-    show: (text, x, y, fadeInTime = 100) ->
+    setText: (text) ->
         @$('.tooltip-inner', @element).html(
             '<div class="php-atom-autocomplete-popover-wrapper">' + text.replace(/\n/g, '<br/>') + '</div>'
         )
 
+    ###*
+     * Shows a popover at the specified location with the specified text and fade in time.
+     *
+     * @param {int}    x          The X coordinate to show the popover at (left).
+     * @param {int}    y          The Y coordinate to show the popover at (top).
+     * @param {int}    fadeInTime The amount of time to take to fade in the tooltip.
+    ###
+    show: (x, y, fadeInTime = 100) ->
         @$(@element).css('left', x + 'px')
         @$(@element).css('top', y + 'px')
 

--- a/lib/services/popover.coffee
+++ b/lib/services/popover.coffee
@@ -3,21 +3,12 @@
 module.exports =
 
 class Popover extends Disposable
-    ###
-        NOTE: The reason we do not use Atom's native tooltip is because it is attached to an element, which caused
-        strange problems such as tickets #107 and #72. This implementation uses the same CSS classes and transitions but
-        handles the displaying manually as we don't want to attach/detach, we only want to temporarily display a popover
-        on mouseover.
-    ###
     element: null
-    elementToAttachTo: null
 
     ###*
      * Constructor.
-     *
-     * @param {HTMLElement} elementToAttachTo The element to show the popover over.
     ###
-    constructor: (@elementToAttachTo) ->
+    constructor: () ->
         @$ = require 'jquery'
 
         @element = document.createElement('div')
@@ -31,29 +22,34 @@ class Popover extends Disposable
 
     ###*
      * Destructor.
-     *
     ###
     destructor: () ->
         @hide()
         document.body.removeChild(@element)
 
     ###*
-     * Shows a tooltip containing the documentation of the specified element located at the specified location.
+     * Retrieves the HTML element containing the popover.
+     *
+     * @return {HTMLElement}
+    ###
+    getElement: () ->
+        return @element
+
+    ###*
+     * Shows a popover at the specified location with the specified text and fade in time.
      *
      * @param {string} text       The text to display.
+     * @param {int}    x          The X coordinate to show the popover at (left).
+     * @param {int}    y          The Y coordinate to show the popover at (top).
      * @param {int}    fadeInTime The amount of time to take to fade in the tooltip.
     ###
-    show: (text, fadeInTime = 100) ->
-        coordinates = @elementToAttachTo.getBoundingClientRect();
-
-        centerOffset = ((coordinates.right - coordinates.left) / 2)
-
+    show: (text, x, y, fadeInTime = 100) ->
         @$('.tooltip-inner', @element).html(
             '<div class="php-atom-autocomplete-popover-wrapper">' + text.replace(/\n/g, '<br/>') + '</div>'
         )
 
-        @$(@element).css('left', (coordinates.left - (@$(@element).width() / 2) + centerOffset) + 'px')
-        @$(@element).css('top', (coordinates.bottom) + 'px')
+        @$(@element).css('left', x + 'px')
+        @$(@element).css('top', y + 'px')
 
         @$(@element).addClass('in')
         @$(@element).css('opacity', 100)

--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -94,7 +94,8 @@ class AbstractProvider
 
         if tooltipText?.length > 0
             @attachedPopover = new AttachedPopover(element)
-            @attachedPopover.showAfter(tooltipText, delay, fadeInTime)
+            @attachedPopover.setText('<div style="margin-top: -1em;">' + tooltipText + '</div>')
+            @attachedPopover.showAfter(delay, fadeInTime)
 
     ###*
      * Removes the popover, if it is displayed.

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -18,7 +18,7 @@
 }
 
 .php-atom-autocomplete-popover-wrapper {
-    margin: -1em 0em 0em 0em;
+    margin: 0em 0em 0em 0em;
     text-align: left;
 
     .section {

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -17,7 +17,7 @@
     margin-left: -50%;
 }
 
-.php-atom-autocomplete-tooltip-wrapper {
+.php-atom-autocomplete-popover-wrapper {
     margin: -1em 0em 0em 0em;
     text-align: left;
 


### PR DESCRIPTION
Hello

This splits off the popover code used in the tooltip providers into two separate classes: `Popover` and `AttachedPopover`.
  * `Popover`: can have text set and will show or hide itself by calling its methods at specified X and Y coordinates.
  * `AttachedPopover`: same as `Popover`, but attaches itself to a specific element, displaying itself at its location.

The new code is now also used in the `function-provider` for the annotation popovers, so they display immediately. This fixes #156.