### PR TITLE
Enhancement - Ticket #136 - Don't insert a parameter list when one is already present.

### DIFF
--- a/lib/providers/abstract-provider.coffee
+++ b/lib/providers/abstract-provider.coffee
@@ -25,10 +25,10 @@ class AbstractProvider
         return @fetchSuggestions({editor, bufferPosition, scopeDescriptor, prefix})
 
     ###*
-     * Builds a snipper for a PHP function
+     * Builds a snippet for a PHP function
      * @param {string} word     Function name
      * @param {array}  elements All arguments for the snippet (parameters, optionals)
-     * @return string The snipper
+     * @return string The snippet
     ###
     getFunctionSnippet: (word, elements) ->
         body = word + "("
@@ -52,9 +52,26 @@ class AbstractProvider
                 body += arg
             body += "]}"
 
-        body += ")$0"
+        body += ")"
+
+        # Ensure the user ends up after the inserted text when he's done cycling through the parameters with tab.
+        body += "$0"
 
         return body
+
+    ###*
+     * Builds the signature for a PHP function
+     * @param {string} word     Function name
+     * @param {array}  elements All arguments for the signature (parameters, optionals)
+     * @return string The signature
+    ###
+    getFunctionSignature: (word, element) ->
+        snippet = @getFunctionSnippet(word, element)
+
+        # Just strip out the placeholders.
+        signature = snippet.replace(/\$\{\d+:([^\}]+)\}/g, '$1')
+
+        return signature[0 .. -3]
 
     ###*
      * Get prefix from bufferPosition and @regex

--- a/lib/providers/function-provider.coffee
+++ b/lib/providers/function-provider.coffee
@@ -27,16 +27,22 @@ class FunctionProvider extends AbstractProvider
         @functions = proxy.functions()
         return unless @functions.names?
 
-        suggestions = @findSuggestionsForPrefix(prefix.trim())
+        characterAfterPrefix = editor.getTextInRange([bufferPosition, [bufferPosition.row, bufferPosition.column + 1]])
+        insertParameterList = if characterAfterPrefix == '(' then false else true
+
+        suggestions = @findSuggestionsForPrefix(prefix.trim(), insertParameterList)
         return unless suggestions.length
         return suggestions
 
     ###*
-     * Returns suggestions available matching the given prefix
-     * @param {string} prefix Prefix to match
-     * @return array
+     * Returns suggestions available matching the given prefix.
+     *
+     * @param {string} prefix              Prefix to match.
+     * @param {bool}   insertParameterList Whether to insert a list of parameters.
+     *
+     * @return {Array}
     ###
-    findSuggestionsForPrefix: (prefix) ->
+    findSuggestionsForPrefix: (prefix, insertParameterList = true) ->
         # Filter the words using fuzzaldrin
         words = fuzzaldrin.filter @functions.names, prefix
 
@@ -50,7 +56,8 @@ class FunctionProvider extends AbstractProvider
                     description: 'Built-in PHP function.' # Needed or the 'More' button won't show up.
                     descriptionMoreURL: config.config.php_documentation_base_url.functions + word
                     className: if element.args.deprecated then 'php-atom-autocomplete-strike' else ''
-                    snippet: @getFunctionSnippet(word, element.args),
+                    snippet: if insertParameterList then @getFunctionSnippet(word, element.args) else null
+                    displayText: @getFunctionSignature(word, element.args)
                     replacementPrefix: prefix
 
         return suggestions


### PR DESCRIPTION
Hello

This implements #136 and will stop the providers for functions, methods and constructors from inserting the parameter list when one is already present. Only the character index right after the insertion point will be checked, so your cursor must be right before the opening parenthesis for this to be prevented. In all other cases, the full parameter list will be inserted. Regardless of what happens, the autocompletion suggestion will still show the entire signature for clarity.

Hopefully this will increase usability for everyone (I know it will for me, at least ;-).