### PR TITLE
Enhancement - Ticket #121 - Implement tooltips for classes.

### DIFF
--- a/lib/goto/class-provider.coffee
+++ b/lib/goto/class-provider.coffee
@@ -49,27 +49,10 @@ class ClassProvider extends AbstractProvider
      *
      * @param  {jQuery.Event}  event  A jQuery event.
      *
-     * @return {object|null}          A selector to be used with jQuery.
+     * @return {object|null} A selector to be used with jQuery.
     ###
     getSelectorFromEvent: (event) ->
-        selector = event.currentTarget
-
-        if @$(selector).hasClass('builtin') or @$(selector).children('.builtin').length > 0
-            return null
-
-        if @$(selector).parent().hasClass('function argument')
-            return @$(selector).parent().children('.namespace, .class:not(.operator):not(.constant)')
-
-        if @$(selector).prev().hasClass('namespace') && @$(selector).hasClass('class')
-            return @$([@$(selector).prev()[0], selector])
-
-        if @$(selector).next().hasClass('class') && @$(selector).hasClass('namespace')
-           return @$([selector, @$(selector).next()[0]])
-
-        if @$(selector).prev().hasClass('namespace') || @$(selector).next().hasClass('inherited-class')
-            return @$(selector).parent().children('.namespace, .inherited-class')
-
-        return selector
+        return @parser.getClassSelectorFromEvent(event)
 
     ###*
      * Goes through all the lines within the editor looking for classes within comments. More specifically if they have

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -685,6 +685,35 @@ module.exports =
         return editor.getTextInBufferRange([startBufferPosition, endBufferPosition])
 
     ###*
+     * Gets the correct selector when a class or namespace is clicked.
+     *
+     * @param  {jQuery.Event}  event  A jQuery event.
+     *
+     * @return {object|null} A selector to be used with jQuery.
+    ###
+    getClassSelectorFromEvent: (event) ->
+        selector = event.currentTarget
+
+        $ = require 'jquery'
+
+        if $(selector).hasClass('builtin') or $(selector).children('.builtin').length > 0
+            return null
+
+        if $(selector).parent().hasClass('function argument')
+            return $(selector).parent().children('.namespace, .class:not(.operator):not(.constant)')
+
+        if $(selector).prev().hasClass('namespace') && $(selector).hasClass('class')
+            return $([$(selector).prev()[0], selector])
+
+        if $(selector).next().hasClass('class') && $(selector).hasClass('namespace')
+           return $([selector, $(selector).next()[0]])
+
+        if $(selector).prev().hasClass('namespace') || $(selector).next().hasClass('inherited-class')
+            return $(selector).parent().children('.namespace, .inherited-class')
+
+        return selector
+
+    ###*
      * Gets the parent class of the current class opened in the editor
      * @param  {TextEditor} editor Editor with the class in.
      * @return {string}            The namespace and class of the parent

--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -93,7 +93,9 @@ class AbstractProvider
         tooltipText = @getTooltipForWord(editor, term, bufferPosition)
 
         if tooltipText?.length > 0
-            @attachedPopover = new AttachedPopover(element)
+            popoverElement = @getPopoverElementFromSelector(element)
+
+            @attachedPopover = new AttachedPopover(popoverElement)
             @attachedPopover.setText('<div style="margin-top: -1em;">' + tooltipText + '</div>')
             @attachedPopover.showAfter(delay, fadeInTime)
 
@@ -121,3 +123,11 @@ class AbstractProvider
     ###
     getSelectorFromEvent: (event) ->
         return event.currentTarget
+
+    ###*
+     * Gets the correct element to attach the popover to from the retrieved selector.
+     * @param  {jQuery.Event}  event  A jQuery event.
+     * @return {object|null}          A selector to be used with jQuery.
+    ###
+    getPopoverElementFromSelector: (selector) ->
+        return selector

--- a/lib/tooltip/class-provider.coffee
+++ b/lib/tooltip/class-provider.coffee
@@ -1,0 +1,77 @@
+{TextEditor} = require 'atom'
+
+proxy = require './abstract-provider'
+AbstractProvider = require './abstract-provider'
+
+module.exports =
+
+class ClassProvider extends AbstractProvider
+    hoverEventSelectors: '.entity.inherited-class, .support.namespace, .support.class, .comment-clickable .region'
+
+    ###*
+     * Retrieves a tooltip for the word given.
+     * @param  {TextEditor} editor         TextEditor to search for namespace of term.
+     * @param  {string}     term           Term to search for.
+     * @param  {Point}      bufferPosition The cursor location the term is at.
+    ###
+    getTooltipForWord: (editor, term, bufferPosition) ->
+        fullClassName = @parser.getFullClassName(editor, term)
+
+        proxy = require '../services/php-proxy.coffee'
+        classInfo = proxy.methods(fullClassName)
+
+        if not classInfo or not classInfo.wasFound
+            return
+
+        type = ''
+
+        if classInfo.isClass
+            type = (if classInfo.isAbstract then 'abstract ' else '') + 'class'
+
+        else if classInfo.isTrait
+            type = 'trait'
+
+        else if classInfo.isInterface
+            type = 'interface'
+
+        # Create a useful description to show in the tooltip.
+        description = ''
+
+        description += "<p><div>"
+        description +=     type + ' ' + '<strong>' + classInfo.shortName + '</strong> &mdash; ' + classInfo.class
+        description += '</div></p>'
+
+        # Show the summary (short description).
+        description += '<div>'
+        description +=     (if classInfo.args.descriptions.short then classInfo.args.descriptions.short else '(No documentation available)')
+        description += '</div>'
+
+        # Show the (long) description.
+        if classInfo.args.descriptions.long?.length > 0
+            description += '<div class="section">'
+            description +=     "<h4>Description</h4>"
+            description +=     "<div>" + classInfo.args.descriptions.long + "</div>"
+            description += "</div>"
+
+        return description
+
+    ###*
+     * Gets the correct selector when a class or namespace is clicked.
+     *
+     * @param  {jQuery.Event}  event  A jQuery event.
+     *
+     * @return {object|null} A selector to be used with jQuery.
+    ###
+    getSelectorFromEvent: (event) ->
+        return @parser.getClassSelectorFromEvent(event)
+
+    ###*
+     * Gets the correct element to attach the popover to from the retrieved selector.
+     * @param  {jQuery.Event}  event  A jQuery event.
+     * @return {object|null}          A selector to be used with jQuery.
+    ###
+    getPopoverElementFromSelector: (selector) ->
+        # getSelectorFromEvent can return multiple items because namespaces and class names are different HTML elements.
+        # We have to select one to attach the popover to.
+        array = @$(selector).toArray()
+        return array[array.length - 1]

--- a/lib/tooltip/tooltip-manager.coffee
+++ b/lib/tooltip/tooltip-manager.coffee
@@ -1,3 +1,4 @@
+ClassProvider = require './class-provider.coffee'
 FunctionProvider = require './function-provider.coffee'
 PropertyProvider = require './property-provider.coffee'
 
@@ -10,6 +11,7 @@ class TooltipManager
      * Initializes the tooltip providers.
     ###
     init: () ->
+        @providers.push new ClassProvider()
         @providers.push new FunctionProvider()
         @providers.push new PropertyProvider()
 


### PR DESCRIPTION
Hello

This implements ticket #121. Classes, interfaces and traits will now have tooltips showing their documentation. The tooltip shows the class name, the full class name, the summary and the long description (if it is available).

As a nice side effect, use statements that point to a class, trait or interface will also have tooltips.