### PR TITLE
Bugfix - Fix sticky popovers.

### DIFF
--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -116,9 +116,7 @@ class FunctionProvider extends AbstractProvider
                             @attachedPopover.show()
 
                         @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'mouseout', selector, (event) =>
-                            if @attachedPopover
-                                @attachedPopover.dispose()
-                                @attachedPopover = null
+                            @removePopover()
 
                         @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'click', selector, (event) =>
                             referencedObject = if value.override then value.override else value.implementation
@@ -127,6 +125,23 @@ class FunctionProvider extends AbstractProvider
                                 initialLine    : referencedObject.startLine - 1,
                                 searchAllPanes : true
                             })
+
+                        # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
+                        # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
+                        # it.
+                        @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
+                            @removePopover()
+
+                        @$(textEditorElement.shadowRoot).find('.vertical-scrollbar').on 'scroll', () =>
+                            @removePopover()
+
+    ###*
+     * Removes the popover, if it is displayed.
+    ###
+    removePopover: () ->
+        if @attachedPopover
+            @attachedPopover.dispose()
+            @attachedPopover = null
 
     ###*
      * Removes any markers previously created by registerMarkers.

--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -79,6 +79,15 @@ class AbstractProvider
             @subAtom.add scrollViewElement, 'mouseout', @hoverEventSelectors, (event) =>
                 @removePopover()
 
+            # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
+            # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
+            # it.
+            @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
+                @removePopover()
+
+            @$(textEditorElement.shadowRoot).find('.vertical-scrollbar').on 'scroll', () =>
+                @removePopover()
+
     ###*
      * Shows a popover containing the documentation of the specified element located at the specified location.
      *


### PR DESCRIPTION
Hello

This fixes the sticky popovers mentioned in pull request #174. This also fixes the same problem for the annotation popovers. Furthermore, the 'stickyness' that popovers seem to have always had is now gone as they are removed when the view scrolls.

The problem was that when Atom scrolls an element out of the view, the element is removed from the DOM and the mouseout event is never sent anymore, leaving the popover in a frozen state on the screen.