### PR TITLE
Bugfix/Refactoring - Split off annotations and fix more pesky tooltips.

### DIFF
--- a/lib/annotation/abstract-provider.coffee
+++ b/lib/annotation/abstract-provider.coffee
@@ -12,7 +12,7 @@ class AbstractProvider
 
         atom.workspace.observeTextEditors (editor) =>
             editor.onDidSave (event) =>
-                @rescanAnnotations(editor)
+                @rescan(editor)
 
             @registerAnnotations editor
             @registerEvents editor

--- a/lib/annotation/abstract-provider.coffee
+++ b/lib/annotation/abstract-provider.coffee
@@ -1,0 +1,78 @@
+{TextEditor} = require 'atom'
+
+SubAtom = require 'sub-atom'
+
+module.exports =
+
+class AbstractProvider
+    ###*
+     * Initializes this provider.
+    ###
+    init: () ->
+        @$ = require 'jquery'
+        @parser = require '../services/php-file-parser'
+
+        atom.workspace.observeTextEditors (editor) =>
+            editor.onDidSave (event) =>
+                @rescanAnnotations(editor)
+
+            @registerAnnotations editor
+            @registerEvents editor
+
+        # When you go back to only have 1 pane the events are lost, so need to re-register.
+        atom.workspace.onDidDestroyPane (pane) =>
+            panes = atom.workspace.getPanes()
+
+            if panes.length == 1
+                for paneItem in panes[0].items
+                    if paneItem instanceof TextEditor
+                        @registerEvents paneItem
+
+        # Having to re-register events as when a new pane is created the old panes lose the events.
+        atom.workspace.onDidAddPane (observedPane) =>
+            panes = atom.workspace.getPanes()
+
+            for pane in panes
+                if pane == observedPane
+                    continue
+
+                for paneItem in pane.items
+                    if paneItem instanceof TextEditor
+                        @registerEvents paneItem
+
+    ###*
+     * Deactives the provider.
+    ###
+    deactivate: () ->
+        @removeAnnotations()
+
+    ###*
+     * Registers event handlers.
+     *
+     * @param {TextEditor} editor TextEditor to register events to.
+    ###
+    registerEvents: (editor) ->
+        #if editor.getGrammar().scopeName.match /text.html.php$/
+
+    ###*
+     * Registers the annotations.
+     *
+     * @param {TextEditor} editor The editor to search through.
+    ###
+    registerAnnotations: (editor) ->
+
+    ###*
+     * Removes any annotations that were created.
+     *
+     * @param {TextEditor} editor The editor to search through.
+    ###
+    removeAnnotations: (editor) ->
+
+    ###*
+     * Rescans the editor, updating all annotations.
+     *
+     * @param {TextEditor} editor The editor to search through.
+    ###
+    rescan: (editor) ->
+        @removeAnnotations(editor)
+        @registerAnnotations(editor)

--- a/lib/annotation/abstract-provider.coffee
+++ b/lib/annotation/abstract-provider.coffee
@@ -1,7 +1,5 @@
 {TextEditor} = require 'atom'
 
-SubAtom = require 'sub-atom'
-
 module.exports =
 
 class AbstractProvider

--- a/lib/annotation/annotation-manager.coffee
+++ b/lib/annotation/annotation-manager.coffee
@@ -1,0 +1,22 @@
+MethodProvider = require './method-provider.coffee'
+
+module.exports =
+
+class AnnotationManager
+    providers: []
+
+    ###*
+     * Initializes the tooltip providers.
+    ###
+    init: () ->
+        @providers.push new MethodProvider()
+
+        for provider in @providers
+            provider.init(@)
+
+    ###*
+     * Deactivates the tooltip providers.
+    ###
+    deactivate: () ->
+        for provider in @providers
+            provider.deactivate()

--- a/lib/annotation/method-provider.coffee
+++ b/lib/annotation/method-provider.coffee
@@ -1,0 +1,136 @@
+{Range} = require 'atom'
+{Point} = require 'atom'
+{TextEditor} = require 'atom'
+
+SubAtom = require 'sub-atom'
+AbstractProvider = require './abstract-provider'
+AttachedPopover = require '../services/attached-popover'
+
+module.exports =
+
+class FunctionProvider extends AbstractProvider
+    annotationMarkers: []
+    annotationSubAtoms: []
+
+    ###*
+     * Registers event handlers.
+     *
+     * @param {TextEditor} editor TextEditor to register events to.
+    ###
+    registerEvents: (editor) ->
+        if editor.getGrammar().scopeName.match /text.html.php$/
+            # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
+            # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
+            # it.
+            editor.onDidDestroy () =>
+                @removePopover()
+
+            editor.onDidStopChanging () =>
+                @removePopover()
+
+            textEditorElement = atom.views.getView(editor)
+
+            @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
+                @removePopover()
+
+            @$(textEditorElement.shadowRoot).find('.vertical-scrollbar').on 'scroll', () =>
+                @removePopover()
+
+    ###*
+     * Registers the annotations.
+     *
+     * @param {TextEditor} editor The editor to search through
+    ###
+    registerAnnotations: (editor) ->
+        text = editor.getText()
+        rows = text.split('\n')
+        @annotationSubAtoms[editor.getLongTitle()] = new SubAtom
+
+        for rowNum,row of rows
+            regex = /(\s*(?:public|protected|private)\s+function\s+)(\w+)\s*\(/g
+
+            while (match = regex.exec(row))
+                currentClass = @parser.getFullClassName(editor)
+
+                methodName = match[2]
+
+                value = @parser.getMethodContext(editor, methodName, null, currentClass)
+
+                if not value
+                    continue
+
+                if value.override or value.implementation
+                    range = new Range(
+                        new Point(parseInt(rowNum), match[1].length),
+                        new Point(parseInt(rowNum), match[1].length + methodName.length)
+                    )
+
+                    marker = editor.markBufferRange(range, {
+                        maintainHistory: true,
+                        invalidate: 'touch'
+                    })
+
+                    annotationClass = if value.override then 'override' else 'implementation'
+
+                    decoration = editor.decorateMarker(marker, {
+                        type: 'line-number',
+                        class: annotationClass
+                    })
+
+                    if @annotationMarkers[editor.getLongTitle()] == undefined
+                        @annotationMarkers[editor.getLongTitle()] = []
+
+                    @annotationMarkers[editor.getLongTitle()].push(marker)
+
+                    # Add tooltips and click handlers to the annotations.
+                    textEditorElement = atom.views.getView(editor)
+                    gutterContainerElement = @$(textEditorElement.shadowRoot).find('.gutter-container')
+
+                    do (gutterContainerElement, methodName, value, editor) =>
+                        selector = '.line-number' + '.' + annotationClass + '[data-buffer-row=' + rowNum + '] .icon-right'
+
+                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'mouseover', selector, (event) =>
+                            tooltipText = ''
+
+                            # NOTE: We explicitly show the declaring class here, not the structure (which could be a
+                            # trait).
+                            if value.override
+                                tooltipText += 'Overrides method from ' + value.override.declaringClass.name
+
+                            else
+                                tooltipText += 'Implements method for ' + value.implementation.declaringClass.name
+
+                            @attachedPopover = new AttachedPopover(event.target)
+                            @attachedPopover.setText(tooltipText)
+                            @attachedPopover.show()
+
+                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'mouseout', selector, (event) =>
+                            @removePopover()
+
+                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'click', selector, (event) =>
+                            referencedObject = if value.override then value.override else value.implementation
+
+                            atom.workspace.open(referencedObject.declaringStructure.filename, {
+                                initialLine    : referencedObject.startLine - 1,
+                                searchAllPanes : true
+                            })
+
+    ###*
+     * Removes any annotations that were created.
+     *
+     * @param {TextEditor} editor The editor to search through
+    ###
+    removeAnnotations: (editor) ->
+        for i,marker of @annotationMarkers[editor.getLongTitle()]
+            marker.destroy()
+
+        @annotationMarkers[editor.getLongTitle()] = []
+        @annotationSubAtoms[editor.getLongTitle()]?.dispose()
+
+    ###*
+     * Removes the popover, if it is displayed.
+    ###
+    removePopover: () ->
+        if @attachedPopover
+            @attachedPopover.dispose()
+            @attachedPopover = null

--- a/lib/goto/abstract-provider.coffee
+++ b/lib/goto/abstract-provider.coffee
@@ -201,24 +201,6 @@ class AbstractProvider
     getJumpToRegex: (term) ->
 
     ###*
-     * Jumps to a word within the editor.
-     *
-     * @param {TextEditor} editor The editor that has the function in.
-     * @param {string} word       The word to find and then jump to.
-     *
-     * @example Invoking it on MyMethod::foo()->bar() will ask what class 'bar' is invoked on, which will whatever type
-     *          foo returns.
-    ###
-    getCalledClass: (editor, term, bufferPosition) ->
-        proxy = require '../services/php-proxy.coffee'
-        fullCall = @parser.getStackClasses(editor, bufferPosition)
-
-        if fullCall?.length == 0 or !term
-          return
-
-        return @parser.parseElements(editor, bufferPosition, fullCall)
-
-    ###*
      * Jumps to a word within the editor
      * @param  {TextEditor} editor The editor that has the function in.
      * @param  {string} word       The word to find and then jump to.

--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -57,6 +57,8 @@ class FunctionProvider extends AbstractProvider
         rows = text.split('\n')
         @annotationSubAtoms[editor.getLongTitle()] = new SubAtom
 
+        textEditorElement = atom.views.getView(editor)
+
         for rowNum,row of rows
             regex = /(\s*(?:public|protected|private)\s+function\s+)(\w+)\s*\(/g
 
@@ -94,7 +96,6 @@ class FunctionProvider extends AbstractProvider
                     @annotationMarkers[editor.getLongTitle()].push(marker)
 
                     # Add tooltips and click handlers to the annotations.
-                    textEditorElement = atom.views.getView(editor)
                     gutterContainerElement = @$(textEditorElement.shadowRoot).find('.gutter-container')
 
                     do (gutterContainerElement, methodName, value, editor) =>
@@ -126,14 +127,20 @@ class FunctionProvider extends AbstractProvider
                                 searchAllPanes : true
                             })
 
-                        # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
-                        # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
-                        # it.
-                        @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
-                            @removePopover()
+        # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
+        # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
+        # it.
+        editor.onDidDestroy () =>
+            @removePopover()
 
-                        @$(textEditorElement.shadowRoot).find('.vertical-scrollbar').on 'scroll', () =>
-                            @removePopover()
+        editor.onDidStopChanging () =>
+            @removePopover()
+
+        @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
+            @removePopover()
+
+        @$(textEditorElement.shadowRoot).find('.vertical-scrollbar').on 'scroll', () =>
+            @removePopover()
 
     ###*
      * Removes the popover, if it is displayed.

--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -1,10 +1,6 @@
-{Range} = require 'atom'
-{Point} = require 'atom'
 {TextEditor} = require 'atom'
 
-SubAtom = require 'sub-atom'
 AbstractProvider = require './abstract-provider'
-AttachedPopover = require '../services/attached-popover'
 
 module.exports =
 
@@ -12,8 +8,6 @@ class FunctionProvider extends AbstractProvider
     hoverEventSelectors: '.function-call'
     clickEventSelectors: '.function-call'
     gotoRegex: /^(\$\w+)?((->|::)\w+\()+/
-    annotationMarkers: []
-    annotationSubAtoms: []
 
     ###*
      * Goto the class from the term given.
@@ -46,121 +40,6 @@ class FunctionProvider extends AbstractProvider
         })
 
         @manager.addBackTrack(editor.getPath(), bufferPosition)
-
-    ###*
-     * Register any markers that you need.
-     *
-     * @param {TextEditor} editor The editor to search through
-    ###
-    registerMarkers: (editor) ->
-        text = editor.getText()
-        rows = text.split('\n')
-        @annotationSubAtoms[editor.getLongTitle()] = new SubAtom
-
-        textEditorElement = atom.views.getView(editor)
-
-        for rowNum,row of rows
-            regex = /(\s*(?:public|protected|private)\s+function\s+)(\w+)\s*\(/g
-
-            while (match = regex.exec(row))
-                currentClass = @parser.getFullClassName(editor)
-
-                methodName = match[2]
-
-                value = @parser.getMethodContext(editor, methodName, null, currentClass)
-
-                if not value
-                    continue
-
-                if value.override or value.implementation
-                    range = new Range(
-                        new Point(parseInt(rowNum), match[1].length),
-                        new Point(parseInt(rowNum), match[1].length + methodName.length)
-                    )
-
-                    marker = editor.markBufferRange(range, {
-                        maintainHistory: true,
-                        invalidate: 'touch'
-                    })
-
-                    annotationClass = if value.override then 'override' else 'implementation'
-
-                    decoration = editor.decorateMarker(marker, {
-                        type: 'line-number',
-                        class: annotationClass
-                    })
-
-                    if @annotationMarkers[editor.getLongTitle()] == undefined
-                        @annotationMarkers[editor.getLongTitle()] = []
-
-                    @annotationMarkers[editor.getLongTitle()].push(marker)
-
-                    # Add tooltips and click handlers to the annotations.
-                    gutterContainerElement = @$(textEditorElement.shadowRoot).find('.gutter-container')
-
-                    do (gutterContainerElement, methodName, value, editor) =>
-                        selector = '.line-number' + '.' + annotationClass + '[data-buffer-row=' + rowNum + '] .icon-right'
-
-                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'mouseover', selector, (event) =>
-                            tooltipText = ''
-
-                            # NOTE: We explicitly show the declaring class here, not the structure (which could be a
-                            # trait).
-                            if value.override
-                                tooltipText += 'Overrides method from ' + value.override.declaringClass.name
-
-                            else
-                                tooltipText += 'Implements method for ' + value.implementation.declaringClass.name
-
-                            @attachedPopover = new AttachedPopover(event.target)
-                            @attachedPopover.setText(tooltipText)
-                            @attachedPopover.show()
-
-                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'mouseout', selector, (event) =>
-                            @removePopover()
-
-                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'click', selector, (event) =>
-                            referencedObject = if value.override then value.override else value.implementation
-
-                            atom.workspace.open(referencedObject.declaringStructure.filename, {
-                                initialLine    : referencedObject.startLine - 1,
-                                searchAllPanes : true
-                            })
-
-        # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
-        # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
-        # it.
-        editor.onDidDestroy () =>
-            @removePopover()
-
-        editor.onDidStopChanging () =>
-            @removePopover()
-
-        @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
-            @removePopover()
-
-        @$(textEditorElement.shadowRoot).find('.vertical-scrollbar').on 'scroll', () =>
-            @removePopover()
-
-    ###*
-     * Removes the popover, if it is displayed.
-    ###
-    removePopover: () ->
-        if @attachedPopover
-            @attachedPopover.dispose()
-            @attachedPopover = null
-
-    ###*
-     * Removes any markers previously created by registerMarkers.
-     *
-     * @param {TextEditor} editor The editor to search through
-    ###
-    cleanMarkers: (editor) ->
-        for i,marker of @annotationMarkers[editor.getLongTitle()]
-            marker.destroy()
-
-        @annotationMarkers[editor.getLongTitle()] = []
-        @annotationSubAtoms[editor.getLongTitle()]?.dispose()
 
     ###*
      * Gets the regex used when looking for a word within the editor

--- a/lib/peekmo-php-atom-autocomplete.coffee
+++ b/lib/peekmo-php-atom-autocomplete.coffee
@@ -6,6 +6,7 @@ VariableProvider = require "./providers/variable-provider.coffee"
 
 GotoManager = require "./goto/goto-manager.coffee"
 TooltipManager = require "./tooltip/tooltip-manager.coffee"
+AnnotationManager = require "./annotation/annotation-manager.coffee"
 
 config = require './config.coffee'
 proxy = require './services/php-proxy.coffee'
@@ -59,6 +60,9 @@ module.exports =
         @tooltipManager = new TooltipManager()
         @tooltipManager.init()
 
+        @annotationManager = new AnnotationManager()
+        @annotationManager.init()
+
         proxy.init()
 
     deactivate: ->
@@ -66,6 +70,7 @@ module.exports =
 
         @gotoManager.deactivate()
         @tooltipManager.deactivate()
+        @annotationManager.deactivate()
 
     registerProviders: ->
         @providers.push new ConstantProvider()

--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -42,7 +42,7 @@ class AbstractProvider
                         @registerEvents paneItem
 
     ###*
-     * Deactives the goto feature.
+     * Deactives the provider.
     ###
     deactivate: () ->
         document.removeChild(@popover)

--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -82,6 +82,12 @@ class AbstractProvider
             # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
             # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
             # it.
+            editor.onDidDestroy () =>
+                @removePopover()
+
+            editor.onDidStopChanging () =>
+                @removePopover()
+
             @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
                 @removePopover()
 


### PR DESCRIPTION
Hello

This refactors annotations into separate providers (because they really did not belong in the go to providers) and fixes #155. I've also fixed some additional issues with popovers freezing when one was being shown while the editor closed or the element attached to was removed while it was open.