### PR TITLE
Bugfix - Ticket #178 - Fixed closures not being scanned for type hints.

### DIFF
--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -538,7 +538,7 @@ module.exports =
                 if null != matches
                     return @getFullClassName(editor, matches[1])
 
-            # We've reached the function definition, check for type hints and/or the docblock.
+            # We've reached the function definition, other variables don't apply to this scope.
             if chain.indexOf("function") != -1
                 break
 


### PR DESCRIPTION
Hello

This fixes #178, where closures were not examined for type hints when fetching the type of local variables. Next to that, the regex was updated as it was generating problems if the first type hint was a FQCN prefixed by a slash (in that case it could not determine the type of the variable from the first parameter type hint correctly).

I also fixed an issue where the line text kept getting larger and larger because all the text in the range from the line to the cursor position was fetched. This probably never caused any problems because the regexes (regices?) were matching the first part of the string anyway and the other parts of the string, that were wrongly included, were already checked for the same regex. The fix should also improve performance a bit because there is less text to scan.