### PR TITLE
Enhancement - Implement a smarter addUseClass.

### DIFF
--- a/lib/autocompletion/class-provider.coffee
+++ b/lib/autocompletion/class-provider.coffee
@@ -110,23 +110,24 @@ class ClassProvider extends AbstractProvider
 
         if suggestion.data.kind == 'instantiation' or suggestion.data.kind == 'static'
             editor.transact () =>
-                added = parser.addUseClass(editor, suggestion.text)
+                linesAdded = parser.addUseClass(editor, suggestion.text)
 
                 # Removes namespace from classname
-                if added?
+                if linesAdded != null
                     name = suggestion.text
                     splits = name.split('\\')
 
                     nameLength = splits[splits.length-1].length
-                    wordStart = triggerPosition.column - suggestion.data.prefix.length
-                    lineStart = if added == "added" then triggerPosition.row + 1 else triggerPosition.row
+                    startColumn = triggerPosition.column - suggestion.data.prefix.length
+                    row = triggerPosition.row + linesAdded
 
                     if suggestion.data.kind == 'instantiation'
-                        lineEnd = wordStart + name.length - nameLength - splits.length + 1
+                        endColumn = startColumn + name.length - nameLength - splits.length + 1
+
                     else
-                        lineEnd = wordStart + name.length - nameLength
+                        endColumn = startColumn + name.length - nameLength
 
                     editor.setTextInBufferRange([
-                        [lineStart, wordStart],
-                        [lineStart, lineEnd] # Because when selected there's not \ (why?)
+                        [row, startColumn],
+                        [row, endColumn] # Because when selected there's not \ (why?)
                     ], "")

--- a/lib/autocompletion/class-provider.coffee
+++ b/lib/autocompletion/class-provider.coffee
@@ -1,6 +1,7 @@
 fuzzaldrin = require 'fuzzaldrin'
 exec = require "child_process"
 
+config = require "../config.coffee"
 proxy = require "../services/php-proxy.coffee"
 parser = require "../services/php-file-parser.coffee"
 AbstractProvider = require "./abstract-provider"
@@ -110,7 +111,7 @@ class ClassProvider extends AbstractProvider
 
         if suggestion.data.kind == 'instantiation' or suggestion.data.kind == 'static'
             editor.transact () =>
-                linesAdded = parser.addUseClass(editor, suggestion.text)
+                linesAdded = parser.addUseClass(editor, suggestion.text, config.config.insertNewlinesForUseStatements)
 
                 # Removes namespace from classname
                 if linesAdded != null

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -19,6 +19,7 @@ module.exports =
         @config['autoload'] = atom.config.get('atom-autocomplete-php.autoloadPaths')
         @config['classmap'] = atom.config.get('atom-autocomplete-php.classMapFiles')
         @config['packagePath'] = atom.packages.resolvePackagePath('atom-autocomplete-php')
+        @config['insertNewlinesForUseStatements'] = atom.config.get('atom-autocomplete-php.insertNewlinesForUseStatements')
 
     ###*
      * Writes configuration in "php lib" folder
@@ -105,4 +106,7 @@ module.exports =
             @writeConfig()
 
         atom.config.onDidChange 'atom-autocomplete-php.classMapFiles', () =>
+            @writeConfig()
+
+        atom.config.onDidChange 'atom-autocomplete-php.insertNewlinesForUseStatements', () =>
             @writeConfig()

--- a/lib/peekmo-php-atom-autocomplete.coffee
+++ b/lib/peekmo-php-atom-autocomplete.coffee
@@ -41,6 +41,15 @@ module.exports =
             default: ['vendor/composer/autoload_classmap.php', 'autoload/ezp_kernel.php']
             order: 4
 
+        insertNewlinesForUseStatements:
+            title: 'Insert newlines for use statements.'
+            description: 'When enabled, the plugin will add additional newlines before or after an automatically added
+                use statement when it can\'t add them nicely to an existing group. This results in more cleanly
+                separated use statements but will create additional vertical whitespace.'
+            type: 'boolean'
+            default: false
+            order: 5
+
     activate: ->
         # See also pull request #197 - Disabled for now because it does not allow the user to reactivate or try again.
         # return unless config.testConfig()

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -209,21 +209,22 @@ module.exports =
                     #if lastUse and score < @scoreClassName(lastUse, matches[1])
                     #    bestScore = 0 # Don't try to squeeze in between good pairs.
 
-                    if score >= bestScore and (not lastUse or score > @scoreClassName(lastUse, matches[1]))
-                        bestUse = i
-                        bestScore = score
-                        placeBelow = if className.length >= matches[1].length then true else false
+                    if score >= bestScore
+                        #if not lastUse or score > @scoreClassName(lastUse, matches[1])
+                        if true
+                            bestUse = i
+                            bestScore = score
 
+                            if @shareCommonNamespacePrefix(className, matches[1])
+                                doNewLine = false
+                                placeBelow = if className.length >= matches[1].length then true else false
 
+                            else
+                                doNewLine = true
+                                placeBelow = true
 
+                        #else
 
-                        firstClassNameParts = className.split('\\')
-                        secondClassNameParts = matches[1].split('\\')
-
-                        firstClassNameParts.pop()
-                        secondClassNameParts.pop()
-
-                        doNewLine = if firstClassNameParts.join('\\') == secondClassNameParts.join('\\') then false else true
 
                     lastUse = matches[1]
 
@@ -232,6 +233,16 @@ module.exports =
 
         return null
 
+
+
+    shareCommonNamespacePrefix: (firstClassName, secondClassName) ->
+        firstClassNameParts = firstClassName.split('\\')
+        secondClassNameParts = secondClassName.split('\\')
+
+        firstClassNameParts.pop()
+        secondClassNameParts.pop()
+
+        return if firstClassNameParts.join('\\') == secondClassNameParts.join('\\') then true else false
 
 
 
@@ -256,16 +267,13 @@ module.exports =
             if firstClassNameParts[i] == secondClassNameParts[i]
                 totalScore += 2
 
-        firstClassNameParts.pop()
-        secondClassNameParts.pop()
-
-        if firstClassNameParts.length == secondClassNameParts.length
+        if @shareCommonNamespacePrefix(firstClassName, secondClassName)
             if firstClassName.length == secondClassName.length
                 totalScore += 2
 
             else
                 # Stick closer to items that are smaller in length than items that are larger in length.
-                totalScore -= 0.001 * (secondClassName.length - firstClassName.length)
+                totalScore -= 0.001 * Math.abs(secondClassName.length - firstClassName.length)
 
         return totalScore
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -145,13 +145,15 @@ module.exports =
     ###*
      * Add the use for the given class if not already added.
      *
-     * @param {TextEditor} editor    Atom text editor.
-     * @param {string}     className Name of the class to add.
+     * @param {TextEditor} editor                  Atom text editor.
+     * @param {string}     className               Name of the class to add.
+     * @param {boolean}    allowAdditionalNewlines Whether to allow adding additional newlines to attempt to group use
+     *                                             statements.
      *
      * @return {int}       The amount of lines added (including newlines), so you can reliably and easily offset your
      *                     rows. This could be zero if a use statement was already present.
     ###
-    addUseClass: (editor, className) ->
+    addUseClass: (editor, className, allowAdditionalNewlines) ->
         if className.split('\\').length == 1 or className.indexOf('\\') == 0
             return null
 
@@ -160,12 +162,6 @@ module.exports =
         placeBelow = true
         doNewLine = true
         lineCount = editor.getLineCount()
-
-
-        # TODO: There should be a config option that passes a flag to this method to NEVER add extra newlines
-        # (doNewLine) as some people like it concise. For others, the new heuristic won't matter mutch as they are used
-        # to having it dumped at the end. At least now it will end up in a slightly more related location.
-
 
         # Determine an appropriate location to place the use statement.
         for i in [0 .. lineCount - 1]
@@ -207,6 +203,9 @@ module.exports =
 
         # Insert the use statement itself.
         lineEnding = editor.getBuffer().lineEndingForRow(0)
+
+        if not allowAdditionalNewlines
+            doNewLine = false
 
         if not lineEnding
             lineEnding = "\n"

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -166,13 +166,21 @@ module.exports =
         lineCount = editor.getLineCount()
 
 
-        # TODO: This should probably skip comments.
+        # TODO: There should be a config option that passes a flag to this method to NEVER add extra newlines
+        # (doNewLine) as some people like it concise. For others, the new heuristic won't matter mutch as they are used
+        # to having it dumped at the end. At least now it will end up in a slightly more related location.
         # TODO: This should probably also stop on trait, interface, ...
         # TODO: Needs a load of refactoring, but commit and push first so we can revert if we break things.
 
 
         for i in [0 .. lineCount - 1]
             line = editor.lineTextForBufferRow(i).trim()
+
+            if line.length = 0
+                continue
+
+            else if editor.scopeDescriptorForBufferPosition([i, line.length]).getScopeChain().indexOf('.comment') >= 0
+                continue
 
             # If we found class keyword, we are not in namespace space, so return
             if line.indexOf('class ') != -1


### PR DESCRIPTION
Hello

This implements a  'smarter' `addUseClass` that will not just place the use statements under the last use statement, but will try to find the existing use statement that it thinks it fits the most and place the new use statement there. Together with a new configuration option (disabled by default to not annoy anyone) which you can use to also allow inserting newlines, this will hopefully result in much cleaner lists of use statements.

The reason for this is that most implementations usually aren't very smart when it comes to use statements. After a while of coding, the result is something like this:

```php
use A\B\C\D\E;
use A\B;
use MoreCodeHere\SomeNamespace\SomeLongerName;
use B\F\A;
use MyFoo\Bar\Something;
...
```

With these changes and the newline option enabled, the package will try to group them and give them more sensible locations:

```php
use MyBar;

use MyFoo\MyBar1;
use MyFoo\MyBar2;

use MyFoo\MyFoo2\MyBar3;

...
```

This implementation can never be perfect and is highly subject to preference, but will at least help in providing more readable groups of use statements. As the adding of newlines is disabled by default, the new implementation should never be worse for anyone than the current implementation as in the worst case, it will just place the use statement at the bottom like before, whilst in the best case, it will place it next to a use statement that looks a lot like it, increasing readability.

Finally, this also refactors and improves `addUseClass`, making it stop on other structural keywords such as `interface`, `trait` and `abstract class` as well, improving performance.