### PR TITLE
Enhancement - Ticket #144 - Add annotations for properties.

### DIFF
--- a/lib/annotation/abstract-provider.coffee
+++ b/lib/annotation/abstract-provider.coffee
@@ -138,16 +138,6 @@ class AbstractProvider
      * @param {Array}      match
     ###
     extractAnnotationInfo: (editor, row, rowText, match) ->
-        currentClass = @parser.getFullClassName(editor)
-
-        propertyName = match[2]
-
-        context = @parser.getPropertyContext(editor, propertyName, null, currentClass)
-
-        if not context or not context.override
-            return null
-
-        return context
 
     ###*
      * Registers annotation event handlers for the specified row.

--- a/lib/annotation/abstract-provider.coffee
+++ b/lib/annotation/abstract-provider.coffee
@@ -1,8 +1,17 @@
-{TextEditor} = require 'atom'
+{Range, Point, TextEditor} = require 'atom'
+
+SubAtom = require 'sub-atom'
+
+AttachedPopover = require '../services/attached-popover'
 
 module.exports =
 
 class AbstractProvider
+    # The regular expression that a line must match in order for it to be checked if it requires an annotation.
+    regex: null
+    markers: []
+    subAtoms: []
+
     ###*
      * Initializes this provider.
     ###
@@ -50,7 +59,23 @@ class AbstractProvider
      * @param {TextEditor} editor TextEditor to register events to.
     ###
     registerEvents: (editor) ->
-        #if editor.getGrammar().scopeName.match /text.html.php$/
+        if editor.getGrammar().scopeName.match /text.html.php$/
+            # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
+            # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
+            # it.
+            editor.onDidDestroy () =>
+                @removePopover()
+
+            editor.onDidStopChanging () =>
+                @removePopover()
+
+            textEditorElement = atom.views.getView(editor)
+
+            @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
+                @removePopover()
+
+            @$(textEditorElement.shadowRoot).find('.vertical-scrollbar').on 'scroll', () =>
+                @removePopover()
 
     ###*
      * Registers the annotations.
@@ -58,6 +83,137 @@ class AbstractProvider
      * @param {TextEditor} editor The editor to search through.
     ###
     registerAnnotations: (editor) ->
+        text = editor.getText()
+        rows = text.split('\n')
+        @subAtoms[editor.getLongTitle()] = new SubAtom
+
+        for rowNum,row of rows
+            while (match = @regex.exec(row))
+                @placeAnnotation(editor, rowNum, row, match)
+
+    ###*
+     * Places an annotation at the specified line and row text.
+     *
+     * @param {TextEditor} editor
+     * @param {int}        row
+     * @param {String}     rowText
+     * @param {Array}      match
+    ###
+    placeAnnotation: (editor, row, rowText, match) ->
+        annotationInfo = @extractAnnotationInfo(editor, row, rowText, match)
+
+        if not annotationInfo
+            return
+
+        range = new Range(
+            new Point(parseInt(row), 0),
+            new Point(parseInt(row), rowText.length)
+        )
+
+        marker = editor.markBufferRange(range, {
+            maintainHistory : true,
+            invalidate      : 'touch'
+        })
+
+        decoration = editor.decorateMarker(marker, {
+            type: 'line-number',
+            class: annotationInfo.lineNumberClass
+        })
+
+        longTitle = editor.getLongTitle()
+
+        if @markers[longTitle] == undefined
+            @markers[longTitle] = []
+
+        @markers[longTitle].push(marker)
+
+        @registerAnnotationEventHandlers(editor, row, annotationInfo)
+
+    ###*
+     * Exracts information about the annotation match.
+     *
+     * @param {TextEditor} editor
+     * @param {int}        row
+     * @param {String}     rowText
+     * @param {Array}      match
+    ###
+    extractAnnotationInfo: (editor, row, rowText, match) ->
+        currentClass = @parser.getFullClassName(editor)
+
+        propertyName = match[2]
+
+        context = @parser.getPropertyContext(editor, propertyName, null, currentClass)
+
+        if not context or not context.override
+            return null
+
+        return context
+
+    ###*
+     * Registers annotation event handlers for the specified row.
+     *
+     * @param {TextEditor} editor
+     * @param {int}        row
+     * @param {Object}     annotationInfo
+    ###
+    registerAnnotationEventHandlers: (editor, row, annotationInfo) ->
+        textEditorElement = atom.views.getView(editor)
+        gutterContainerElement = @$(textEditorElement.shadowRoot).find('.gutter-container')
+
+        do (editor, gutterContainerElement, annotationInfo) =>
+            longTitle = editor.getLongTitle()
+            selector = '.line-number' + '.' + annotationInfo.lineNumberClass + '[data-buffer-row=' + row + '] .icon-right'
+
+            @subAtoms[longTitle].add gutterContainerElement, 'mouseover', selector, (event) =>
+                @handleMouseOver(event, editor, annotationInfo)
+
+            @subAtoms[longTitle].add gutterContainerElement, 'mouseout', selector, (event) =>
+                @handleMouseOut(event, editor, annotationInfo)
+
+            @subAtoms[longTitle].add gutterContainerElement, 'click', selector, (event) =>
+                @handleMouseClick(event, editor, annotationInfo)
+
+    ###*
+     * Handles the mouse over event on an annotation.
+     *
+     * @param {jQuery.Event} event
+     * @param {TextEditor}   editor
+     * @param {Object}       annotationInfo
+    ###
+    handleMouseOver: (event, editor, annotationInfo) ->
+        if annotationInfo.tooltipText
+            @removePopover()
+
+            @attachedPopover = new AttachedPopover(event.target)
+            @attachedPopover.setText(annotationInfo.tooltipText)
+            @attachedPopover.show()
+
+    ###*
+     * Handles the mouse out event on an annotation.
+     *
+     * @param {jQuery.Event} event
+     * @param {TextEditor}   editor
+     * @param {Object}       annotationInfo
+    ###
+    handleMouseOut: (event, editor, annotationInfo) ->
+        @removePopover()
+
+    ###*
+     * Handles the mouse click event on an annotation.
+     *
+     * @param {jQuery.Event} event
+     * @param {TextEditor}   editor
+     * @param {Object}       annotationInfo
+    ###
+    handleMouseClick: (event, editor, annotationInfo) ->
+
+    ###*
+     * Removes the existing popover, if any.
+    ###
+    removePopover: () ->
+        if @attachedPopover
+            @attachedPopover.dispose()
+            @attachedPopover = null
 
     ###*
      * Removes any annotations that were created.
@@ -65,6 +221,11 @@ class AbstractProvider
      * @param {TextEditor} editor The editor to search through.
     ###
     removeAnnotations: (editor) ->
+        for i,marker of @markers[editor.getLongTitle()]
+            marker.destroy()
+
+        @markers[editor.getLongTitle()] = []
+        @subAtoms[editor.getLongTitle()]?.dispose()
 
     ###*
      * Rescans the editor, updating all annotations.

--- a/lib/annotation/annotation-manager.coffee
+++ b/lib/annotation/annotation-manager.coffee
@@ -1,4 +1,5 @@
 MethodProvider = require './method-provider.coffee'
+PropertyProvider = require './property-provider.coffee'
 
 module.exports =
 
@@ -10,6 +11,7 @@ class AnnotationManager
     ###
     init: () ->
         @providers.push new MethodProvider()
+        @providers.push new PropertyProvider()
 
         for provider in @providers
             provider.init(@)

--- a/lib/annotation/method-provider.coffee
+++ b/lib/annotation/method-provider.coffee
@@ -1,137 +1,56 @@
-{Range} = require 'atom'
-{Point} = require 'atom'
-{TextEditor} = require 'atom'
-
-SubAtom = require 'sub-atom'
 AbstractProvider = require './abstract-provider'
-AttachedPopover = require '../services/attached-popover'
 
 module.exports =
 
 # Provides annotations for overriding methods and implementations of interface methods.
 class FunctionProvider extends AbstractProvider
-    annotationMarkers: []
-    annotationSubAtoms: []
+    regex: /(\s*(?:public|protected|private)\s+function\s+)(\w+)\s*\(/g
 
     ###*
-     * Registers event handlers.
-     *
-     * @param {TextEditor} editor TextEditor to register events to.
+     * @inheritdoc
     ###
-    registerEvents: (editor) ->
-        if editor.getGrammar().scopeName.match /text.html.php$/
-            # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
-            # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
-            # it.
-            editor.onDidDestroy () =>
-                @removePopover()
+    extractAnnotationInfo: (editor, row, rowText, match) ->
+        currentClass = @parser.getFullClassName(editor)
 
-            editor.onDidStopChanging () =>
-                @removePopover()
+        propertyName = match[2]
 
-            textEditorElement = atom.views.getView(editor)
+        context = @parser.getMethodContext(editor, propertyName, null, currentClass)
 
-            @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
-                @removePopover()
+        if not context or (not context.override and not context.implementation)
+            return null
 
-            @$(textEditorElement.shadowRoot).find('.vertical-scrollbar').on 'scroll', () =>
-                @removePopover()
+        extraData = null
+        tooltipText = ''
+        lineNumberClass = ''
+
+        # NOTE: We deliberately show the declaring class here, not the structure (which could be a trait).
+        if context.override
+            extraData = context.override
+            lineNumberClass = 'override'
+            tooltipText = 'Overrides method from ' + extraData.declaringClass.name
+
+        else
+            extraData = context.implementation
+            lineNumberClass = 'implementation'
+            tooltipText = 'Implements method for ' + extraData.declaringClass.name
+
+        return {
+            lineNumberClass : lineNumberClass
+            tooltipText     : tooltipText
+            extraData       : extraData
+        }
 
     ###*
-     * Registers the annotations.
-     *
-     * @param {TextEditor} editor The editor to search through
+     * @inheritdoc
     ###
-    registerAnnotations: (editor) ->
-        text = editor.getText()
-        rows = text.split('\n')
-        @annotationSubAtoms[editor.getLongTitle()] = new SubAtom
-
-        for rowNum,row of rows
-            regex = /(\s*(?:public|protected|private)\s+function\s+)(\w+)\s*\(/g
-
-            while (match = regex.exec(row))
-                currentClass = @parser.getFullClassName(editor)
-
-                methodName = match[2]
-
-                value = @parser.getMethodContext(editor, methodName, null, currentClass)
-
-                if not value
-                    continue
-
-                if value.override or value.implementation
-                    range = new Range(
-                        new Point(parseInt(rowNum), match[1].length),
-                        new Point(parseInt(rowNum), match[1].length + methodName.length)
-                    )
-
-                    marker = editor.markBufferRange(range, {
-                        maintainHistory: true,
-                        invalidate: 'touch'
-                    })
-
-                    annotationClass = if value.override then 'override' else 'implementation'
-
-                    decoration = editor.decorateMarker(marker, {
-                        type: 'line-number',
-                        class: annotationClass
-                    })
-
-                    if @annotationMarkers[editor.getLongTitle()] == undefined
-                        @annotationMarkers[editor.getLongTitle()] = []
-
-                    @annotationMarkers[editor.getLongTitle()].push(marker)
-
-                    # Add tooltips and click handlers to the annotations.
-                    textEditorElement = atom.views.getView(editor)
-                    gutterContainerElement = @$(textEditorElement.shadowRoot).find('.gutter-container')
-
-                    do (gutterContainerElement, methodName, value, editor) =>
-                        selector = '.line-number' + '.' + annotationClass + '[data-buffer-row=' + rowNum + '] .icon-right'
-
-                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'mouseover', selector, (event) =>
-                            tooltipText = ''
-
-                            # NOTE: We explicitly show the declaring class here, not the structure (which could be a
-                            # trait).
-                            if value.override
-                                tooltipText += 'Overrides method from ' + value.override.declaringClass.name
-
-                            else
-                                tooltipText += 'Implements method for ' + value.implementation.declaringClass.name
-
-                            @removePopover()
-
-                            @attachedPopover = new AttachedPopover(event.target)
-                            @attachedPopover.setText(tooltipText)
-                            @attachedPopover.show()
-
-                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'mouseout', selector, (event) =>
-                            @removePopover()
-
-                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'click', selector, (event) =>
-                            referencedObject = if value.override then value.override else value.implementation
-
-                            atom.workspace.open(referencedObject.declaringStructure.filename, {
-                                initialLine    : referencedObject.startLine - 1,
-                                searchAllPanes : true
-                            })
+    handleMouseClick: (event, editor, annotationInfo) ->
+        atom.workspace.open(annotationInfo.extraData.declaringStructure.filename, {
+            initialLine    : annotationInfo.extraData.startLine - 1,
+            searchAllPanes : true
+        })
 
     ###*
-     * Removes any annotations that were created.
-     *
-     * @param {TextEditor} editor The editor to search through
-    ###
-    removeAnnotations: (editor) ->
-        for i,marker of @annotationMarkers[editor.getLongTitle()]
-            marker.destroy()
-
-        @annotationMarkers[editor.getLongTitle()] = []
-        @annotationSubAtoms[editor.getLongTitle()]?.dispose()
-
-    ###*
-     * Removes the popover, if it is displayed.
+     * @inheritdoc
     ###
     removePopover: () ->
         if @attachedPopover

--- a/lib/annotation/method-provider.coffee
+++ b/lib/annotation/method-provider.coffee
@@ -14,7 +14,7 @@ class FunctionProvider extends AbstractProvider
 
         propertyName = match[2]
 
-        context = @parser.getMethodContext(editor, propertyName, null, currentClass)
+        context = @parser.getMemberContext(editor, propertyName, null, currentClass)
 
         if not context or (not context.override and not context.implementation)
             return null

--- a/lib/annotation/property-provider.coffee
+++ b/lib/annotation/property-provider.coffee
@@ -14,7 +14,7 @@ class FunctionProvider extends AbstractProvider
 
         propertyName = match[2]
 
-        context = @parser.getPropertyContext(editor, propertyName, null, currentClass)
+        context = @parser.getMemberContext(editor, propertyName, null, currentClass)
 
         if not context or not context.override
             return null

--- a/lib/annotation/property-provider.coffee
+++ b/lib/annotation/property-provider.coffee
@@ -1,135 +1,36 @@
-{Range} = require 'atom'
-{Point} = require 'atom'
-{TextEditor} = require 'atom'
-
-SubAtom = require 'sub-atom'
 AbstractProvider = require './abstract-provider'
-AttachedPopover = require '../services/attached-popover'
 
 module.exports =
 
 # Provides annotations for overriding property.
 class FunctionProvider extends AbstractProvider
-    annotationMarkers: []
-    annotationSubAtoms: []
+    regex: /(\s*(?:public|protected|private)\s+\$)(\w+)\s+/g
 
     ###*
-     * Registers event handlers.
-     *
-     * @param {TextEditor} editor TextEditor to register events to.
+     * @inheritdoc
     ###
-    registerEvents: (editor) ->
-        if editor.getGrammar().scopeName.match /text.html.php$/
-            # Ticket #107 - Mouseout isn't generated until the mouse moves, even when scrolling (with the keyboard or
-            # mouse). If the element goes out of the view in the meantime, its HTML element disappears, never removing
-            # it.
-            editor.onDidDestroy () =>
-                @removePopover()
+    extractAnnotationInfo: (editor, row, rowText, match) ->
+        currentClass = @parser.getFullClassName(editor)
 
-            editor.onDidStopChanging () =>
-                @removePopover()
+        propertyName = match[2]
 
-            textEditorElement = atom.views.getView(editor)
+        context = @parser.getPropertyContext(editor, propertyName, null, currentClass)
 
-            @$(textEditorElement.shadowRoot).find('.horizontal-scrollbar').on 'scroll', () =>
-                @removePopover()
+        if not context or not context.override
+            return null
 
-            @$(textEditorElement.shadowRoot).find('.vertical-scrollbar').on 'scroll', () =>
-                @removePopover()
+        # NOTE: We deliberately show the declaring class here, not the structure (which could be a trait).
+        return {
+            lineNumberClass : 'override'
+            tooltipText     : 'Overrides property from ' + context.override.declaringClass.name
+            extraData       : context.override
+        }
 
     ###*
-     * Registers the annotations.
-     *
-     * @param {TextEditor} editor The editor to search through
+     * @inheritdoc
     ###
-    registerAnnotations: (editor) ->
-        text = editor.getText()
-        rows = text.split('\n')
-        @annotationSubAtoms[editor.getLongTitle()] = new SubAtom
-
-        for rowNum,row of rows
-            regex = /(\s*(?:public|protected|private)\s+\$)(\w+)\s+/g
-
-            while (match = regex.exec(row))
-                currentClass = @parser.getFullClassName(editor)
-
-                propertyName = match[2]
-
-                value = @parser.getPropertyContext(editor, propertyName, null, currentClass)
-
-                if not value
-                    continue
-
-                if value.override
-                    range = new Range(
-                        new Point(parseInt(rowNum), match[1].length),
-                        new Point(parseInt(rowNum), match[1].length + propertyName.length)
-                    )
-
-                    marker = editor.markBufferRange(range, {
-                        maintainHistory: true,
-                        invalidate: 'touch'
-                    })
-
-                    annotationClass = 'override'
-
-                    decoration = editor.decorateMarker(marker, {
-                        type: 'line-number',
-                        class: annotationClass
-                    })
-
-                    if @annotationMarkers[editor.getLongTitle()] == undefined
-                        @annotationMarkers[editor.getLongTitle()] = []
-
-                    @annotationMarkers[editor.getLongTitle()].push(marker)
-
-                    # Add tooltips and click handlers to the annotations.
-                    textEditorElement = atom.views.getView(editor)
-                    gutterContainerElement = @$(textEditorElement.shadowRoot).find('.gutter-container')
-
-                    do (gutterContainerElement, propertyName, value, editor) =>
-                        selector = '.line-number' + '.' + annotationClass + '[data-buffer-row=' + rowNum + '] .icon-right'
-
-                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'mouseover', selector, (event) =>
-                            tooltipText = ''
-
-                            # NOTE: We explicitly show the declaring class here, not the structure (which could be a
-                            # trait).
-                            tooltipText += 'Overrides property from ' + value.override.declaringClass.name
-
-                            @removePopover()
-
-                            @attachedPopover = new AttachedPopover(event.target)
-                            @attachedPopover.setText(tooltipText)
-                            @attachedPopover.show()
-
-                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'mouseout', selector, (event) =>
-                            @removePopover()
-
-                        @annotationSubAtoms[editor.getLongTitle()].add gutterContainerElement, 'click', selector, (event) =>
-                            referencedObject = if value.override then value.override else value.implementation
-
-                            atom.workspace.open(referencedObject.declaringStructure.filename, {
-                                initialLine    : referencedObject.startLine - 1,
-                                searchAllPanes : true
-                            })
-
-    ###*
-     * Removes any annotations that were created.
-     *
-     * @param {TextEditor} editor The editor to search through
-    ###
-    removeAnnotations: (editor) ->
-        for i,marker of @annotationMarkers[editor.getLongTitle()]
-            marker.destroy()
-
-        @annotationMarkers[editor.getLongTitle()] = []
-        @annotationSubAtoms[editor.getLongTitle()]?.dispose()
-
-    ###*
-     * Removes the popover, if it is displayed.
-    ###
-    removePopover: () ->
-        if @attachedPopover
-            @attachedPopover.dispose()
-            @attachedPopover = null
+    handleMouseClick: (event, editor, annotationInfo) ->
+        atom.workspace.open(annotationInfo.extraData.declaringStructure.filename, {
+            # initialLine    : annotationInfo.startLine - 1,
+            searchAllPanes : true
+        })

--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -29,7 +29,7 @@ class FunctionProvider extends AbstractProvider
             @manager.addBackTrack(editor.getPath(), bufferPosition)
             return
 
-        value = @parser.getMethodContext(editor, term, bufferPosition, calledClass)
+        value = @parser.getMemberContext(editor, term, bufferPosition, calledClass)
 
         if not value
             return

--- a/lib/goto/property-provider.coffee
+++ b/lib/goto/property-provider.coffee
@@ -29,7 +29,7 @@ class PropertyProvider extends AbstractProvider
             @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
             return
 
-        value = @parser.getPropertyContext(editor, term, bufferPosition, calledClass)
+        value = @parser.getMemberContext(editor, term, bufferPosition, calledClass)
 
         if not value
             return

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -638,14 +638,14 @@ module.exports =
         return bestMatch
 
     ###*
-     * Retrieves contextual information about the property at the specified location in the editor.
+     * Retrieves contextual information about the class member at the specified location in the editor.
      *
      * @param {TextEditor} editor         TextEditor to search for namespace of term.
      * @param {string}     term           Term to search for.
      * @param {Point}      bufferPosition The cursor location the term is at.
      * @param {Object}     calledClass    Information about the called class (optional).
     ###
-    getMethodContext: (editor, term, bufferPosition, calledClass) ->
+    getMemberContext: (editor, term, bufferPosition, calledClass) ->
         if not calledClass
             calledClass = @getCalledClass(editor, term, bufferPosition)
 
@@ -674,40 +674,6 @@ module.exports =
         if value instanceof Array
             for val in value
                 if val.isMethod
-                    value = val
-                    break
-
-        return value
-
-    ###*
-     * Retrieves contextual information about the property at the specified location in the editor.
-     #
-     * @param {TextEditor} editor         TextEditor to search for namespace of term.
-     * @param {string}     name           The name of the property to search for.
-     * @param {Point}      bufferPosition The cursor location the term is at.
-     * @param {Object}     calledClass    Information about the called class (optional).
-    ###
-    getPropertyContext: (editor, name, bufferPosition, calledClass) ->
-        if not calledClass
-            calledClass = @getCalledClass(editor, name, bufferPosition)
-
-        if not calledClass
-            return
-
-        proxy = require '../services/php-proxy.coffee'
-        methodsAndProperties = proxy.methods(calledClass)
-
-        if not methodsAndProperties.names?
-            return
-
-        if methodsAndProperties.names.indexOf(name) == -1
-            return
-
-        value = methodsAndProperties.values[name]
-
-        if value instanceof Array
-            for val in value
-                if !val.isMethod
                     value = val
                     break
 

--- a/lib/tooltip/function-provider.coffee
+++ b/lib/tooltip/function-provider.coffee
@@ -15,7 +15,7 @@ class FunctionProvider extends AbstractProvider
      * @param  {Point}      bufferPosition The cursor location the term is at.
     ###
     getTooltipForWord: (editor, term, bufferPosition) ->
-        value = @parser.getMethodContext(editor, term, bufferPosition)
+        value = @parser.getMemberContext(editor, term, bufferPosition)
 
         if not value
             return

--- a/lib/tooltip/property-provider.coffee
+++ b/lib/tooltip/property-provider.coffee
@@ -14,7 +14,7 @@ class PropertyProvider extends AbstractProvider
      * @param  {Point}      bufferPosition The cursor location the term is at.
     ###
     getTooltipForWord: (editor, term, bufferPosition) ->
-        value = @parser.getPropertyContext(editor, term, bufferPosition)
+        value = @parser.getMemberContext(editor, term, bufferPosition)
 
         if not value
             return

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -313,13 +313,15 @@ abstract class Tools
     protected function getOverrideInfo($reflectionMember)
     {
         $overriddenMember = null;
-        $methodName = $reflectionMember->getName();
+        $memberName = $reflectionMember->getName();
 
         $baseClass = $reflectionMember->getDeclaringClass();
 
+        $type = ($reflectionMember instanceof ReflectionProperty) ? 'Property' : 'Method';
+
         while ($baseClass = $baseClass->getParentClass()) {
-            if ($baseClass->hasMethod($methodName)) {
-                $overriddenMember = $baseClass->getMethod($methodName);
+            if ($baseClass->{'has' . $type}($memberName)) {
+                $overriddenMember = $baseClass->{'get' . $type}($memberName);
                 break;
             }
         }
@@ -329,8 +331,8 @@ abstract class Tools
             // a trait the class it is in is using.
             if ($reflectionMember instanceof ReflectionFunctionAbstract) {
                 foreach ($reflectionMember->getDeclaringClass()->getTraits() as $trait) {
-                    if ($trait->hasMethod($methodName)) {
-                        $traitMethod = $trait->getMethod($methodName);
+                    if ($trait->hasMethod($memberName)) {
+                        $traitMethod = $trait->getMethod($memberName);
 
                         if ($traitMethod->isAbstract()) {
                             $overriddenMember = $traitMethod;


### PR DESCRIPTION
Hello

This pull request:
  * Adds annotations for class properties.
  * Reduces code duplication by merging `getMethodContext` and `getPropertyContext` into one, as they already were mostly the same method.
  * Refactors the annotation provider so the new property provider can reuse most of the code from the existing method provider.