### PR TITLE
Enhancement - Ticket #120 - Show descriptions for the return type and parameters. 

### DIFF
--- a/lib/autocompletion/class-provider.coffee
+++ b/lib/autocompletion/class-provider.coffee
@@ -65,13 +65,16 @@ class ClassProvider extends AbstractProvider
         suggestions = []
 
         for word in words when word isnt prefix
+            classInfo = @classes.mapping[word]
+
             # Just print classes with constructors with "new"
             if instantiation and @classes.mapping[word].methods.constructor.has
-                args = @classes.mapping[word].methods.constructor.args
+                args = classInfo.methods.constructor.args
 
                 suggestions.push
                     text: word,
                     type: 'class',
+                    className: if classInfo.class.deprecated then 'php-atom-autocomplete-strike' else ''
                     snippet: if insertParameterList then @getFunctionSnippet(word, args) else null
                     displayText: @getFunctionSignature(word, args)
                     data:
@@ -84,6 +87,7 @@ class ClassProvider extends AbstractProvider
                     text: word,
                     type: 'class',
                     prefix: prefix,
+                    className: if classInfo.class.deprecated then 'php-atom-autocomplete-strike' else ''
                     replacementPrefix: prefix,
                     data:
                         kind: 'use'
@@ -93,6 +97,7 @@ class ClassProvider extends AbstractProvider
                 suggestions.push
                     text: word,
                     type: 'class',
+                    className: if classInfo.class.deprecated then 'php-atom-autocomplete-strike' else ''
                     data:
                         kind: 'static',
                         prefix: prefix,

--- a/lib/autocompletion/member-provider.coffee
+++ b/lib/autocompletion/member-provider.coffee
@@ -98,7 +98,7 @@ class MemberProvider extends AbstractProvider
                 # Ensure we don't get very long return types by just showing the last part.
                 snippet = null
                 displayText = word
-                returnValueParts = if ele.args.return then ele.args.return.split('\\') else []
+                returnValueParts = if ele.args.return.type then ele.args.return.type.split('\\') else []
                 returnValue = returnValueParts[returnValueParts.length - 1]
 
                 if ele.isMethod

--- a/lib/autocompletion/member-provider.coffee
+++ b/lib/autocompletion/member-provider.coffee
@@ -98,7 +98,7 @@ class MemberProvider extends AbstractProvider
                 # Ensure we don't get very long return types by just showing the last part.
                 snippet = null
                 displayText = word
-                returnValueParts = if ele.args.return.type then ele.args.return.type.split('\\') else []
+                returnValueParts = if ele.args.return?.type then ele.args.return.type.split('\\') else []
                 returnValue = returnValueParts[returnValueParts.length - 1]
 
                 if ele.isMethod

--- a/lib/services/popover.coffee
+++ b/lib/services/popover.coffee
@@ -12,8 +12,7 @@ class Popover extends Disposable
         @$ = require 'jquery'
 
         @element = document.createElement('div')
-        @element.id = 'php-atom-autocomplete-popover'
-        @element.className = 'tooltip bottom fade'
+        @element.className = 'tooltip bottom fade php-atom-autocomplete-popover'
         @element.innerHTML = "<div class='tooltip-arrow'></div><div class='tooltip-inner'></div>"
 
         document.body.appendChild(@element)
@@ -42,7 +41,7 @@ class Popover extends Disposable
     ###
     setText: (text) ->
         @$('.tooltip-inner', @element).html(
-            '<div class="php-atom-autocomplete-popover-wrapper">' + text.replace(/\n/g, '<br/>') + '</div>'
+            '<div class="php-atom-autocomplete-popover-wrapper">' + text.replace(/\n\n/g, '<br/><br/>') + '</div>'
         )
 
     ###*

--- a/lib/tooltip/function-provider.coffee
+++ b/lib/tooltip/function-provider.coffee
@@ -72,32 +72,27 @@ class FunctionProvider extends AbstractProvider
         parametersDescription = ""
 
         for param,info of value.args.docParameters
-            parametersDescription += "<div>"
+            parametersDescription += "<tr>"
 
-
-
-            # TODO: Use a HTML table for the parameters to get a consistent lay-out.
-
-
+            parametersDescription += "<td>•&nbsp;<strong>"
 
             if param in value.args.optionals
-                parametersDescription += "• <strong>[" + param + "]</strong>"
+                parametersDescription += "[" + param + "]"
 
             else
-                parametersDescription += "• <strong>" + param + "</strong>"
+                parametersDescription += param
 
-            if info.type
-                parametersDescription += " &mdash; " + info.type
+            parametersDescription += "</strong></td>"
 
-            if info.description
-                parametersDescription += " &mdash; " + info.description
+            parametersDescription += "<td>" + (if info.type then info.type else '&nbsp;') + '</td>'
+            parametersDescription += "<td>" + (if info.description then info.description else '&nbsp;') + '</td>'
 
-            parametersDescription += "</div>"
+            parametersDescription += "</tr>"
 
         if parametersDescription.length > 0
             description += '<div class="section">'
             description +=     "<h4>Parameters</h4>"
-            description +=     "<div>" + parametersDescription + "</div>"
+            description +=     "<div><table>" + parametersDescription + "</table></div>"
             description += "</div>"
 
         if value.args.return?.type

--- a/lib/tooltip/function-provider.coffee
+++ b/lib/tooltip/function-provider.coffee
@@ -24,7 +24,10 @@ class FunctionProvider extends AbstractProvider
 
         # Show the method's signature.
         accessModifier = ''
-        returnType = (if value.args.return then value.args.return else '')
+        returnType = ''
+
+        if value.args.return?.type
+            returnType = value.args.return.type
 
         if value.isPublic
             accessModifier = 'public'
@@ -68,26 +71,44 @@ class FunctionProvider extends AbstractProvider
         # Show the parameters the method has.
         parametersDescription = ""
 
-        for param in value.args.parameters
+        for param,info of value.args.docParameters
             parametersDescription += "<div>"
-            parametersDescription += "• <strong>" + param + "</strong>"
+
+
+
+            # TODO: Use a HTML table for the parameters to get a consistent lay-out.
+
+
+
+            if param in value.args.optionals
+                parametersDescription += "• <strong>[" + param + "]</strong>"
+
+            else
+                parametersDescription += "• <strong>" + param + "</strong>"
+
+            if info.type
+                parametersDescription += " &mdash; " + info.type
+
+            if info.description
+                parametersDescription += " &mdash; " + info.description
+
             parametersDescription += "</div>"
 
-        for param in value.args.optionals
-            parametersDescription += "<div>"
-            parametersDescription += "• <strong>[" + param + "]</strong>"
-            parametersDescription += "</div>"
-
-        if value.args.parameters.length > 0 or value.args.optionals.length > 0
+        if parametersDescription.length > 0
             description += '<div class="section">'
             description +=     "<h4>Parameters</h4>"
             description +=     "<div>" + parametersDescription + "</div>"
             description += "</div>"
 
-        if value.args.return
+        if value.args.return?.type
+            returnValue = '<strong>' + value.args.return.type + '</strong>'
+
+            if value.args.return.description
+                returnValue += ' ' + value.args.return.description
+
             description += '<div class="section">'
             description +=     "<h4>Returns</h4>"
-            description +=     "<div>" + value.args.return + "</div>"
+            description +=     "<div>" + returnValue + "</div>"
             description += "</div>"
 
         # Show an overview of the exceptions the method can throw.

--- a/lib/tooltip/property-provider.coffee
+++ b/lib/tooltip/property-provider.coffee
@@ -20,7 +20,7 @@ class PropertyProvider extends AbstractProvider
             return
 
         accessModifier = ''
-        returnType = if value.args.return then value.args.return else 'mixed'
+        returnType = if value.args.return?.type then value.args.return.type else 'mixed'
 
         if value.isPublic
             accessModifier = 'public'
@@ -50,10 +50,15 @@ class PropertyProvider extends AbstractProvider
             description +=     "<div>" + value.args.descriptions.long + "</div>"
             description += "</div>"
 
-        if value.args.return
+        if value.args.return?.type
+            returnValue = '<strong>' + value.args.return.type + '</strong>'
+
+            if value.args.return.description
+                returnValue += ' ' + value.args.return.description
+
             description += '<div class="section">'
             description +=     "<h4>Type</h4>"
-            description +=     "<div>" + value.args.return + "</div>"
+            description +=     "<div>" + returnValue + "</div>"
             description += "</div>"
 
         return description

--- a/php/providers/AutocompleteProvider.php
+++ b/php/providers/AutocompleteProvider.php
@@ -43,7 +43,7 @@ class AutocompleteProvider extends Tools implements ProviderInterface
                 }
             }
 
-            $returnValue = $memberInfo['args']['return'];
+            $returnValue = $memberInfo['args']['return']['type'];
 
             if ($returnValue == '$this' || $returnValue == 'static') {
                 $relevantClass = $class;

--- a/php/providers/ClassMapRefresh.php
+++ b/php/providers/ClassMapRefresh.php
@@ -38,7 +38,7 @@ class ClassMapRefresh extends Tools implements ProviderInterface
                         }
 
                         if ($value = $this->buildIndexClass($class)) {
-                            $index['mapping'][$class] = array('methods' => $value);
+                            $index['mapping'][$class] = $value;
                             $index['autocomplete'][] = $class;
                         }
                     }

--- a/php/providers/ClassProvider.php
+++ b/php/providers/ClassProvider.php
@@ -32,6 +32,7 @@ class ClassProvider extends Tools implements ProviderInterface
         }
 
         return array(
+            'class' => $this->getClassArguments($reflection),
             'methods' => array(
                 'constructor' => array(
                     'has'  => !is_null($ctor),

--- a/php/services/DocParser.php
+++ b/php/services/DocParser.php
@@ -87,13 +87,7 @@ class DocParser
             $tagValue = $this->normalizeNewlines($tagValue);
 
             // Remove the delimiters of the docblock itself at the start of each line, if any.
-            // $tagValue = preg_replace("/\n\\s+\\*\\s*/g", ' ', $tagValue);
-            // TODO: Reenable this regex and test multiline descriptions.
-
-
-
-            // TODO: Update docblocks.
-
+            $tagValue = preg_replace('/\n\s+\*\s*/', ' ', $tagValue);
 
             // Collapse multiple spaces, just like HTML does.
             $tagValue = preg_replace('/\s\s+/', ' ', $tagValue);
@@ -121,22 +115,18 @@ class DocParser
             );
         }
 
-
-
-
-        // TODO: Remove me.
-        $result['tmp'] = array(
-            'tags'    => $tags,
-            'matches' => $matches
-        );
-
-
-
-        
-
         return $result;
     }
 
+    /**
+     * Returns an array of three values, the first value will go up until the first space, the second value will go up
+     * until the second space, and the third value will contain the rest of the string. Convenience method for tags that
+     * consist of three parameters.
+     *
+     * @param string $value
+     *
+     * @return string[]
+     */
     protected function filterThreeParameterTag($value)
     {
         $parts = explode(' ', $value);
@@ -153,6 +143,14 @@ class DocParser
         return array($firstPart ?: null, $secondPart ?: null, $thirdPart);
     }
 
+    /**
+     * Returns an array of two values, the first value will go up until the first space and the second value will
+     * contain the rest of the string. Convenience method for tags that consist of two parameters.
+     *
+     * @param string $value
+     *
+     * @return string[]
+     */
     protected function filterTwoParameterTag($value)
     {
         list($firstPart, $secondPart, $thirdPart) = $this->filterThreeParameterTag($value);
@@ -160,6 +158,15 @@ class DocParser
         return array($firstPart, trim($secondPart . ' ' . $thirdPart));
     }
 
+    /**
+     * Filters out information about the return value of the function or method.
+     *
+     * @param string $docblock
+     * @param string $methodName
+     * @param array  $tags
+     *
+     * @return array
+     */
     protected function filterReturn($docblock, $methodName, array $tags)
     {
         if (isset($tags[static::RETURN_VALUE])) {
@@ -180,6 +187,15 @@ class DocParser
         );
     }
 
+    /**
+     * Filters out information about the parameters of the function or method.
+     *
+     * @param string $docblock
+     * @param string $methodName
+     * @param array  $tags
+     *
+     * @return array
+     */
     protected function filterParams($docblock, $methodName, array $tags)
     {
         $params = array();
@@ -200,6 +216,15 @@ class DocParser
         );
     }
 
+    /**
+     * Filters out information about the variable.
+     *
+     * @param string $docblock
+     * @param string $methodName
+     * @param array  $tags
+     *
+     * @return array
+     */
     protected function filterVar($docblock, $methodName, array $tags)
     {
         if (isset($tags[static::VAR_TYPE])) {
@@ -213,6 +238,15 @@ class DocParser
         );
     }
 
+    /**
+     * Filters out deprecation information.
+     *
+     * @param string $docblock
+     * @param string $methodName
+     * @param array  $tags
+     *
+     * @return array
+     */
     protected function filterDeprecated($docblock, $methodName, array $tags)
     {
         return array(
@@ -220,6 +254,15 @@ class DocParser
         );
     }
 
+    /**
+     * Filters out information about what exceptions the method can throw.
+     *
+     * @param string $docblock
+     * @param string $methodName
+     * @param array  $tags
+     *
+     * @return array
+     */
     protected function filterThrows($docblock, $methodName, array $tags)
     {
         $throws = array();
@@ -237,6 +280,15 @@ class DocParser
         );
     }
 
+    /**
+     * Filters out information about the description.
+     *
+     * @param string $docblock
+     * @param string $methodName
+     * @param array  $tags
+     *
+     * @return array
+     */
     protected function filterDescription($docblock, $methodName, array $tags)
     {
         $summary = '';

--- a/php/services/DocParser.php
+++ b/php/services/DocParser.php
@@ -28,15 +28,12 @@ class DocParser
      */
     public function get($className, $type, $name, $filters)
     {
-        $isConstructor = false;
-
         switch($type) {
             case 'function':
                 $reflection = new \ReflectionFunction($name);
                 break;
 
             case 'method':
-                $isConstructor = ($name === '__construct');
                 $reflection = new \ReflectionMethod($className, $name);
                 break;
 
@@ -49,157 +46,203 @@ class DocParser
         }
 
         $comment = $reflection->getDocComment();
-        return $this->parse($comment, $filters, $isConstructor);
+        return $this->parse($comment, $filters, $name);
     }
 
     /**
      * Parse the comment string to get its elements
      *
-     * @param string|false|null $comment       The docblock to parse. If null, the return array will be filled up with the
-     *                                         correct keys, but they will be empty.
-     * @param array             $filters       Elements to search (see constants).
-     * @param bool              $isConstructor Whether or not the method the docblock is for is a constructor.
+     * @param string|false|null $docblock The docblock to parse. If null, the return array will be filled up with the
+     *                                    correct keys, but they will be empty.
+     * @param array             $filters  Elements to search (see constants).
+     * @param string            $itemName The name of the item (method, class, ...) the docblock is for.
      *
      * @return array
      */
-    public function parse($comment, array $filters, $isConstructor)
+    public function parse($docblock, array $filters, $itemName)
     {
-        $comment = is_string($comment) ? $comment : null;
-
-        if ($comment) {
-            $strippedComment = str_replace(array('*', '/'), '', $comment);
-            $escapedComment = $this->replaceNewlines($strippedComment, ' ');
+        if (empty($filters)) {
+            return array();
         }
 
-        $result = array();
+        $result = array_combine($filters, array_fill(0, count($filters), null));
 
-        foreach($filters as $filter) {
-            switch ($filter) {
-                case self::VAR_TYPE:
-                    $result['var'] = null;
+        $docblock = is_string($docblock) ? $docblock : null;
 
-                    if ($comment) {
-                        $var = $this->parseVar($escapedComment);
-                        $result['var'] = $var ?: null;
-                    }
+        if (!$docblock) {
+            return $result;
+        }
 
-                    break;
+        $tags = array();
+        $matches = array();
 
-                case self::RETURN_VALUE:
-                    $result['return'] = null;
+        preg_match_all('/\*\s+(@[a-z-]+)([^@]*)\n/', $docblock, $matches, PREG_SET_ORDER);
 
-                    if ($comment) {
-                        $return = $this->parseVar($escapedComment, self::RETURN_VALUE);
-
-                        if ($return) {
-                            $result['return'] = $return;
-                        } else {
-                            // According to http://www.phpdoc.org/docs/latest/guides/docblocks.html, a method that does
-                            // have a docblock, but no explicit return type returns void. Constructors, however, must
-                            // return self. If there is no docblock at all, we can't assume either of these types.
-                            $result['return'] = $isConstructor ? 'self' : 'void';
-                        }
-                    }
-
-                    break;
-
-                case self::PARAM_TYPE:
-                    $result['params'] = array();
-
-                    if ($comment) {
-                        $res = $escapedComment;
-
-                        while (null !== $ret = $this->parseParams($res)) {
-                            $result['params'][$ret['name']] = $ret['type'];
-                            $res = $ret['string'];
-                        }
-                    }
-
-                    break;
-
-                case self::THROWS:
-                    $result['throws'] = array();
-
-                    if ($comment) {
-                        $res = $escapedComment;
-
-                        while (null !== $ret = $this->parseThrows($res)) {
-                            $res = $ret['string'];
-                            $result['throws'][$ret['type']] = $ret['description'];
-                        }
-                    }
-
-                    break;
-
-                case self::DESCRIPTION:
-                    $result['descriptions'] = array(
-                        'short' => '',
-                        'long'  => ''
-                    );
-
-                    if ($comment) {
-                        list($summary, $description) = $this->parseDescription($comment);
-
-                        $result['descriptions']['short'] = $summary;
-                        $result['descriptions']['long']  = $description;
-                    }
-
-                    break;
-
-                case self::DEPRECATED:
-                    $result['deprecated'] = false;
-
-                    if ($comment) {
-                        $result['deprecated'] = (false !== strpos($escapedComment, self::DEPRECATED));
-                    }
-
-                    break;
+        foreach ($matches as $match) {
+            if (!isset($tags[$match[1]])) {
+                $tags[$match[1]] = array();
             }
+
+            $tagValue = $match[2];
+            $tagValue = $this->normalizeNewlines($tagValue);
+
+            // Remove the delimiters of the docblock itself at the start of each line, if any.
+            // $tagValue = preg_replace("/\n\\s+\\*\\s*/g", ' ', $tagValue);
+            // TODO: Reenable this regex and test multiline descriptions.
+
+
+
+            // TODO: Update docblocks.
+
+
+            // Collapse multiple spaces, just like HTML does.
+            $tagValue = preg_replace('/\s\s+/', ' ', $tagValue);
+
+            $tags[$match[1]][] = trim($tagValue);
         }
+
+        $filterMethodMap = array(
+            static::RETURN_VALUE => 'filterReturn',
+            static::PARAM_TYPE   => 'filterParams',
+            static::VAR_TYPE     => 'filterVar',
+            static::DEPRECATED   => 'filterDeprecated',
+            static::THROWS       => 'filterThrows',
+            static::DESCRIPTION  => 'filterDescription'
+        );
+
+        foreach ($filters as $filter) {
+            if (!isset($filterMethodMap[$filter])) {
+                throw new \UnexpectedValueException('Unknown filter passed!');
+            }
+
+            $result = array_merge(
+                $result,
+                $this->{$filterMethodMap[$filter]}($docblock, $methodName, $tags)
+            );
+        }
+
+
+
+
+        // TODO: Remove me.
+        $result['tmp'] = array(
+            'tags'    => $tags,
+            'matches' => $matches
+        );
+
+
+
+        
 
         return $result;
     }
 
-    /**
-     * Retrieves the specified string with its line separators replaced with the specifed separator.
-     *
-     * @param  string $string
-     * @param  string $replacement
-     *
-     * @return string
-     */
-    private function replaceNewlines($string, $replacement)
+    protected function filterThreeParameterTag($value)
     {
-        return str_replace(array('\n', '\r\n', PHP_EOL), $replacement, $string);
+        $parts = explode(' ', $value);
+
+        $firstPart = trim(array_shift($parts));
+        $secondPart = trim(array_shift($parts));
+
+        if (!empty($parts)) {
+            $thirdPart = trim(implode(' ', $parts));
+        } else {
+            $thirdPart = null;
+        }
+
+        return array($firstPart ?: null, $secondPart ?: null, $thirdPart);
     }
 
-    /**
-     * Normalizes all types of newlines to the "\n" separator.
-     *
-     * @param  string $string
-     *
-     * @return string
-     */
-    private function normalizeNewlines($string)
+    protected function filterTwoParameterTag($value)
     {
-        return $this->replaceNewlines($string, "\n");
+        list($firstPart, $secondPart, $thirdPart) = $this->filterThreeParameterTag($value);
+
+        return array($firstPart, trim($secondPart . ' ' . $thirdPart));
     }
 
-    /**
-     * Search for the long and short description on a method or attribute
-     *
-     * @param string $comment Comment
-     *
-     * @return array ('short' => short description, 'long' => long description)
-     */
-    private function parseDescription($comment)
+    protected function filterReturn($docblock, $methodName, array $tags)
+    {
+        if (isset($tags[static::RETURN_VALUE])) {
+            list($type, $description) = $this->filterTwoParameterTag($tags[static::RETURN_VALUE][0]);
+        } else {
+            // According to http://www.phpdoc.org/docs/latest/guides/docblocks.html, a method that does
+            // have a docblock, but no explicit return type returns void. Constructors, however, must
+            // return self. If there is no docblock at all, we can't assume either of these types.
+            $type = ($methodName === '__construct') ? 'self' : 'void';
+            $description = null;
+        }
+
+        return array(
+            'return' => array(
+                'type'        => $type,
+                'description' => $description
+            )
+        );
+    }
+
+    protected function filterParams($docblock, $methodName, array $tags)
+    {
+        $params = array();
+
+        if (isset($tags[static::PARAM_TYPE])) {
+            foreach ($tags[static::PARAM_TYPE] as $tag) {
+                list($type, $variableName, $description) = $this->filterThreeParameterTag($tag);
+
+                $params[$variableName] = array(
+                    'type'        => $type,
+                    'description' => $description
+                );
+            }
+        }
+
+        return array(
+            'params' => $params
+        );
+    }
+
+    protected function filterVar($docblock, $methodName, array $tags)
+    {
+        if (isset($tags[static::VAR_TYPE])) {
+            list($type, $description) = $this->filterTwoParameterTag($tags[static::VAR_TYPE][0]);
+        } else {
+            $type = null;
+        }
+
+        return array(
+            'var' => $type
+        );
+    }
+
+    protected function filterDeprecated($docblock, $methodName, array $tags)
+    {
+        return array(
+            'deprecated' => isset($tags[static::DEPRECATED])
+        );
+    }
+
+    protected function filterThrows($docblock, $methodName, array $tags)
+    {
+        $throws = array();
+
+        if (isset($tags[static::THROWS])) {
+            foreach ($tags[static::THROWS] as $tag) {
+                list($type, $description) = $this->filterTwoParameterTag($tag);
+
+                $throws[$type] = $description;
+            }
+        }
+
+        return array(
+            'throws' => $throws
+        );
+    }
+
+    protected function filterDescription($docblock, $methodName, array $tags)
     {
         $summary = '';
         $description = '';
 
-        $collapsedComment = $this->normalizeNewlines($comment);
-
-        $lines = explode("\n", $collapsedComment);
+        $lines = explode("\n", $docblock);
 
         $isReadingSummary = true;
 
@@ -224,109 +267,35 @@ class DocParser
         }
 
         return array(
-            trim($summary),
-            trim($description)
+            'descriptions' => array(
+                'short' => trim($summary),
+                'long'  => trim($description)
+            )
         );
     }
 
     /**
-     * Search for a $type in the comment and its value
-     * @param string $string comment string
-     * @param string $type   annotation type searched
+     * Retrieves the specified string with its line separators replaced with the specifed separator.
+     *
+     * @param  string $string
+     * @param  string $replacement
+     *
      * @return string
      */
-    private function parseVar($string, $type = self::VAR_TYPE)
+    protected function replaceNewlines($string, $replacement)
     {
-        if (false === $pos = strpos($string, $type)) {
-            return null;
-        }
-
-        $varSubstring = substr(
-            $string,
-            $pos + strlen($type),
-            strlen($string)-1
-        );
-        $varSubstring = trim($varSubstring);
-
-        if (empty($varSubstring)) {
-            return null;
-        }
-
-        $elements = explode(' ', $varSubstring);
-        return $elements[0];
+        return str_replace(array("\n", "\r\n", PHP_EOL), $replacement, $string);
     }
 
     /**
-     * Search all @param annotations in the given string
-     * @param string $string String comment to search
+     * Normalizes all types of newlines to the "\n" separator.
+     *
+     * @param  string $string
+     *
      * @return string
      */
-    private function parseParams($string)
+    protected function normalizeNewlines($string)
     {
-        if (false === $pos = strpos($string, self::PARAM_TYPE)) {
-            return null;
-        }
-
-        $paramSubstring = substr(
-            $string,
-            $pos + strlen(self::PARAM_TYPE),
-            strlen($string)-1
-        );
-        $paramSubstring = trim($paramSubstring);
-
-        if (empty($paramSubstring)) {
-            return null;
-        }
-
-        $elements = explode(' ', $paramSubstring);
-        if (count($elements) < 2) {
-            return null;
-        }
-
-        return array(
-            'name' => $elements[1],
-            'type' => $elements[0],
-            'string' => $paramSubstring
-        );
-    }
-
-    /**
-     * Search all @throws annotations in the given string
-     * @param string $string String comment to search
-     * @return string
-     */
-    private function parseThrows($string)
-    {
-        if (false === $pos = strpos($string, self::THROWS)) {
-            return null;
-        }
-
-        $throwsSubstring = substr(
-            $string,
-            $pos + strlen(self::THROWS),
-            strlen($string)-1
-        );
-        $throwsSubstring = trim($throwsSubstring);
-
-        if (empty($throwsSubstring)) {
-            return null;
-        }
-
-        // Make sure we don't use the rest of the docblock as description of the exception type.
-        // NOTE: The next tag detection can probably be improved at a later stage.
-        $substringToExplode = $throwsSubstring;
-        $nextTag = strpos($throwsSubstring, '@');
-
-        if ($nextTag !== false) {
-            $substringToExplode = substr($throwsSubstring, 0, $nextTag);
-        }
-
-        $elements = explode(' ', $substringToExplode);
-
-        return array(
-            'type' => trim(array_shift($elements)),
-            'description' => !empty($elements) ? trim(implode(' ', $elements)) : null,
-            'string' => $throwsSubstring
-        );
+        return $this->replaceNewlines($string, "\n");
     }
 }

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -63,7 +63,7 @@ abstract class Tools
        $docParseResult = $parser->parse($docComment, array(
            DocParser::DEPRECATED,
            DocParser::DESCRIPTION
-       ), false);
+       ), $class->getShortName());
 
        return array(
           'descriptions' => $docParseResult['descriptions'],
@@ -121,7 +121,7 @@ abstract class Tools
             DocParser::DEPRECATED,
             DocParser::DESCRIPTION,
             DocParser::RETURN_VALUE
-        ), ($function->name === '__construct'));
+        ), $function->name);
 
         $docblockInheritsLongDescription = false;
 
@@ -227,7 +227,7 @@ abstract class Tools
             DocParser::VAR_TYPE,
             DocParser::DEPRECATED,
             DocParser::DESCRIPTION
-        ), false);
+        ), $property->name);
 
         if (!$docComment) {
             $classIterator = new ReflectionClass($property->class);

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -117,6 +117,7 @@ abstract class Tools
 
         $docParseResult = $parser->parse($docComment, array(
             DocParser::THROWS,
+            DocParser::PARAM_TYPE,
             DocParser::DEPRECATED,
             DocParser::DESCRIPTION,
             DocParser::RETURN_VALUE
@@ -200,12 +201,24 @@ abstract class Tools
         }
 
         return array(
-            'parameters'   => $parameters,
-            'optionals'    => $optionals,
-            'throws'       => $docParseResult['throws'],
-            'return'       => $docParseResult['return'],
-            'descriptions' => $docParseResult['descriptions'],
-            'deprecated'   => $function->isDeprecated() || $docParseResult['deprecated']
+            'parameters'    => $parameters,
+            'optionals'     => $optionals,
+            'docParameters' => $docParseResult['params'],
+            'throws'        => $docParseResult['throws'],
+            'return'        => $docParseResult['return'],
+            'descriptions'  => $docParseResult['descriptions'],
+            'deprecated'    => $function->isDeprecated() || $docParseResult['deprecated'],
+
+
+
+
+
+
+
+
+
+
+            'tmp' => $docParseResult['tmp']
         );
     }
 

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -207,18 +207,7 @@ abstract class Tools
             'throws'        => $docParseResult['throws'],
             'return'        => $docParseResult['return'],
             'descriptions'  => $docParseResult['descriptions'],
-            'deprecated'    => $function->isDeprecated() || $docParseResult['deprecated'],
-
-
-
-
-
-
-
-
-
-
-            'tmp' => $docParseResult['tmp']
+            'deprecated'    => $function->isDeprecated() || $docParseResult['deprecated']
         );
     }
 

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -17,22 +17,37 @@
     margin-left: -50%;
 }
 
-.php-atom-autocomplete-popover-wrapper {
-    margin: 0em 0em 0em 0em;
-    text-align: left;
+.php-atom-autocomplete-popover {
+    max-width: 50%;
 
-    .section {
-        > h4 {
-            margin-top: 1em;
-            font-size: larger;
-            font-weight: bold;
+    .php-atom-autocomplete-popover-wrapper {
+        margin: 0em 0em 0em 0em;
+        text-align: left;
+
+        div {
+            white-space: normal;
         }
 
-        > div {
-            padding-left: 1em;
+        .section {
+            > h4 {
+                margin-top: 1em;
+                font-size: larger;
+                font-weight: bold;
+            }
+
+            > div {
+                padding-left: 1em;
+            }
+
+            td {
+                vertical-align: top;
+            }
+
+            td:not(:last-child) {
+                padding-right: 1em;
+            }
         }
     }
-
 }
 
 atom-text-editor, atom-text-editor::shadow {

--- a/styles/peekmo-php-atom-autocomplete.less
+++ b/styles/peekmo-php-atom-autocomplete.less
@@ -18,7 +18,7 @@
 }
 
 .php-atom-autocomplete-popover {
-    max-width: 50%;
+    max-width: 45%;
 
     .php-atom-autocomplete-popover-wrapper {
         margin: 0em 0em 0em 0em;


### PR DESCRIPTION
Hello

This contains the following changes:
  * Refactor `DocParser` to make the code more flexible and allows (more easily) dealing with tags that may contain newlines in their descriptions.
  * Put a maximum width on the documentation popover, as with very very large descriptions it was filling most of the screen.
  * Don't replace newlines from the original docblock with line breaks. Documentation text should be treated much like HTML: newlines don't actually mean a line break but are merely used when writing the docblock itself. However, when there are two consecutive newlines present, it is clear that the user wants to create a 'section'. In that case, two line breaks are inserted to logically separate the text.
  * Popovers still had an ID assigned, which wasn't used and is also invalid if multiple popovers would ever be active at the same time.
  * Deprecated class names will now also use a strikethrough style when autocompleted.
  * Descriptions and types of parameters and return types are now shown in the docblock (ticket #120).

(I recreated this from a local branch.)