### PR TITLE
Bugfix - Ticket #196 - Fix awkward placement of use statements when containing one of the existing use statements in its own name.

### DIFF
--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -267,7 +267,7 @@ module.exports =
         totalScore = 0
 
         # NOTE: We don't score the last part.
-        for i in [0 .. maxLength - 1]
+        for i in [0 .. maxLength - 2]
             if firstClassNameParts[i] == secondClassNameParts[i]
                 totalScore += 2
 


### PR DESCRIPTION
Hello

This fixes #196 where the use statement would awkwardly squeeze itself in between existing groups when it contained one of the existing use statements in its own namespace.