### PR TITLE
Use marker layers if available to support maintainHistory markers

### DIFF
--- a/lib/annotation/abstract-provider.coffee
+++ b/lib/annotation/abstract-provider.coffee
@@ -110,7 +110,16 @@ class AbstractProvider
             new Point(parseInt(row), rowText.length)
         )
 
-        marker = editor.markBufferRange(range, {
+        # For Atom 1.3 or greater, maintainHistory can only be applied to entire
+        # marker layers. Layers don't exist in earlier versions, hence the
+        # conditional logic.
+        if typeof editor.addMarkerLayer is 'function'
+            @markerLayers ?= new WeakMap
+            unless markerLayer = @markerLayers.get(editor)
+                markerLayer = editor.addMarkerLayer(maintainHistory: true)
+                @markerLayers.set(editor, markerLayer)
+
+        marker = (markerLayer ? editor).markBufferRange(range, {
             maintainHistory : true,
             invalidate      : 'touch'
         })


### PR DESCRIPTION
Hi @Peekmo.

For performance reasons, we needed to drop the `maintainHistory` option when creating individual markers in Atom 1.3. This was a breaking change, but this package was the only user I found.

You can still maintain history on markers, but you now have to create them in their own "marker layer", which groups together related markers, and history is maintained on the entire layer. It's easier for us to save the state of the marker index in the undo history when we aren't mixing historied and unhistoried markers.

Anyway, running this package seems pretty complicated for a non-PHP user like me, so you'll definitely need to test my changes against Atom 1.2 and Atom 1.3, which comes out in beta soon. But this is the approach needed to keep the history tracking on your markers. Please let me know if you have any additional questions. Thanks!