### PR TITLE
Uncaught TypeError: Cannot read property 'length' of undefined Fix #61

### DIFF
--- a/lib/goto/class-provider.coffee
+++ b/lib/goto/class-provider.coffee
@@ -22,7 +22,7 @@ class ClassProvider extends AbstractProvider
         proxy = require '../services/php-proxy.coffee'
         classesResponse = proxy.classes()
 
-        return unless classesResponse
+        return unless classesResponse.autocomplete
 
         @manager.addBackTrack(editor.getPath(), editor.getCursorBufferPosition())
 


### PR DESCRIPTION
The issue with using alt + click on class names still occurred due to classesResponse not being unless and yet not having the autocomplete property. This fixes it.