### PR TITLE
Fix autocompletion for namespace with leading lowercase character - fixes #250

### DIFF
--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -75,9 +75,6 @@ module.exports =
             if noCurrent
                 return null
 
-        else if className.charAt(0).toUpperCase() != className.charAt(0)
-            return null
-
         if className and className[0] == "\\"
             return className.substr(1) # FQCN, not subject to any further context.
 
@@ -556,7 +553,7 @@ module.exports =
 
         # Regex variable definition
         regexElement = new RegExp("\\#{element}[\\s]*=[\\s]*([^;]+);", "g")
-        regexNewInstance = new RegExp("\\#{element}[\\s]*=[\\s]*new[\\s]*\\\\?([A-Z][a-zA-Z_\\\\]*)+(?:(.+)?);", "g")
+        regexNewInstance = new RegExp("\\#{element}[\\s]*=[\\s]*new[\\s]*\\\\?([a-zA-Z][a-zA-Z_\\\\]*)+(?:(.+)?);", "g")
         regexCatch = new RegExp("catch[\\s]*\\([\\s]*([A-Za-z0-9_\\\\]+)[\\s]+\\#{element}[\\s]*\\)", "g")
 
         lineNumber = bufferPosition.row - 1

--- a/php/Config.php
+++ b/php/Config.php
@@ -34,5 +34,3 @@ class Config
         self::$config[$key] = $value;
     }
 }
-
-?>

--- a/php/providers/ClassProvider.php
+++ b/php/providers/ClassProvider.php
@@ -42,5 +42,3 @@ class ClassProvider extends Tools implements ProviderInterface
         );
     }
 }
-
-?>

--- a/php/providers/ConstantsProvider.php
+++ b/php/providers/ConstantsProvider.php
@@ -41,5 +41,3 @@ class ConstantsProvider extends Tools implements ProviderInterface
         return $constants;
     }
 }
-
-?>

--- a/php/providers/DocParamProvider.php
+++ b/php/providers/DocParamProvider.php
@@ -22,5 +22,3 @@ class DocParamProvider extends Tools implements ProviderInterface
         return $parser->get($class, 'method', $name, array(DocParser::PARAM_TYPE));
     }
 }
-
-?>

--- a/php/providers/FunctionsProvider.php
+++ b/php/providers/FunctionsProvider.php
@@ -40,5 +40,3 @@ class FunctionsProvider extends Tools implements ProviderInterface
         return $functions;
     }
 }
-
-?>

--- a/php/services/FileParser.php
+++ b/php/services/FileParser.php
@@ -101,5 +101,3 @@ class FileParser
         return $fullClass;
     }
 }
-
-?>

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -545,5 +545,3 @@ abstract class Tools
         return $data;
     }
 }
-
-?>


### PR DESCRIPTION
As described in #250, the package is not able to autocomplete local variables where the first character of the namespace is a lowercase character. E.g.:

```
$bar = new \foo\Bar;
```

This pull request fixes that issue.