### PR TITLE
Fix error handling

### DIFF
--- a/php/ErrorHandler.php
+++ b/php/ErrorHandler.php
@@ -24,9 +24,9 @@ class ErrorHandler
         ini_set('log_errors', false);
 
         // Register our handlers
-        register_shutdown_function('ErrorHandler::onShutdown');
-        set_error_handler('ErrorHandler::onError');
-        set_exception_handler('ErrorHandler::onException');
+        register_shutdown_function('\Peekmo\AtomAutocompletePhp\ErrorHandler::onShutdown');
+        set_error_handler('\Peekmo\AtomAutocompletePhp\ErrorHandler::onError');
+        set_exception_handler('\Peekmo\AtomAutocompletePhp\ErrorHandler::onException');
     }
 
     /**

--- a/php/services/DocParser.php
+++ b/php/services/DocParser.php
@@ -108,7 +108,7 @@ class DocParser
 
             $result = array_merge(
                 $result,
-                $this->{$filterMethodMap[$filter]}($docblock, $methodName, $tags)
+                $this->{$filterMethodMap[$filter]}($docblock, $itemName, $tags)
             );
         }
 
@@ -228,6 +228,7 @@ class DocParser
             list($type, $description) = $this->filterTwoParameterTag($tags[static::VAR_TYPE][0]);
         } else {
             $type = null;
+            $description = null;
         }
 
         return array(


### PR DESCRIPTION
Currently `php/ErrorHandler.php` sets `display_errors` and `log_errors` to false, which is fine. However it suppresses the PHP warnings  that the subsequent `set_error_handler` etc. calls fail since 03046a1 introduced a namespace on the class.

This pull request calls these function with the FQCN now as needed.

Besides the second commit fixes two uses of undefined variables which were well hidden due to that as well.