### PR TITLE
Fix DocParser parameter name

### DIFF
--- a/php/services/DocParser.php
+++ b/php/services/DocParser.php
@@ -59,7 +59,7 @@ class DocParser
      *
      * @return array
      */
-    public function parse($docblock, array $filters, $methodName)
+    public function parse($docblock, array $filters, $itemName)
     {
         if (empty($filters)) {
             return array();


### PR DESCRIPTION
--Change DocParser::parse parameter $methodName to $itemName

Fixes #258 