### PR TITLE
Fix errors on package deactivation

### DIFF
--- a/lib/annotation/abstract-provider.coffee
+++ b/lib/annotation/abstract-provider.coffee
@@ -220,11 +220,19 @@ class AbstractProvider
      * @param {TextEditor} editor The editor to search through.
     ###
     removeAnnotations: (editor) ->
-        for i,marker of @markers[editor.getLongTitle()]
-            marker.destroy()
-
-        @markers[editor.getLongTitle()] = []
-        @subAtoms[editor.getLongTitle()]?.dispose()
+        if editor?
+            for i,marker of @markers[editor.getLongTitle()]
+                marker.destroy()
+            @markers[editor.getLongTitle()] = []
+            @subAtoms[editor.getLongTitle()]?.dispose()
+        else
+            for i,name of @markers
+                for i,marker of @markers[name]
+                    marker.destroy()
+            @markers = []
+            for i, subAtom of @subAtoms
+                subAtom.dispose()
+            @subAtoms = []
 
     ###*
      * Rescans the editor, updating all annotations.

--- a/lib/tooltip/abstract-provider.coffee
+++ b/lib/tooltip/abstract-provider.coffee
@@ -45,7 +45,6 @@ class AbstractProvider
      * Deactives the provider.
     ###
     deactivate: () ->
-        document.removeChild(@popover)
         @subAtom.dispose()
         @removePopover()
 


### PR DESCRIPTION
This fixes two errors on attempting to deactivate the package:

* The Tooltip provider had a leftover code fragment from an older incarnation that attempted to remove a non-existent element from `document`.
* The Annotation provider called out to `removeAnnotations` with no editor passed in in its `deactivate`, but this wasn't handled in that function.

Fixes #312.