### PR TITLE
Add ability to import use statement outside of autocompletion

### DIFF
--- a/keymaps/atom-autocomplete-php.cson
+++ b/keymaps/atom-autocomplete-php.cson
@@ -2,3 +2,4 @@
   'ctrl-alt-n': 'atom-autocomplete-php:namespace'
   'ctrl-alt-g': 'atom-autocomplete-php:goto'
   'ctrl-shift-Z': 'atom-autocomplete-php:goto-backtrack'
+  'ctrl-alt-u': 'atom-autocomplete-php:import-use-statement'

--- a/lib/autocompletion/class-provider.coffee
+++ b/lib/autocompletion/class-provider.coffee
@@ -35,6 +35,18 @@ class ClassProvider extends AbstractProvider
         return suggestions
 
     ###*
+     * Get suggestions from the provider for a single word (@see provider-api)
+     * @return array
+    ###
+    fetchSuggestionsFromWord: (word) ->
+        @classes = proxy.classes()
+        return unless @classes?.autocomplete?
+
+        suggestions = @findSuggestionsForPrefix(word)
+        return unless suggestions.length
+        return suggestions
+
+    ###*
      * Returns suggestions available matching the given prefix
      * @param {string} prefix              Prefix to match.
      * @param {bool}   insertParameterList Whether to insert a list of parameters for methods.
@@ -137,3 +149,15 @@ class ClassProvider extends AbstractProvider
                         [row, startColumn],
                         [row, endColumn] # Because when selected there's not \ (why?)
                     ], "")
+
+    ###*
+     * Adds the missing use if needed without removing text from editor
+     * @param {TextEditor} editor
+     * @param {object}     suggestion
+    ###
+    onSelectedClassSuggestion: ({editor, suggestion}) ->
+        return unless suggestion.data?.kind
+
+        if suggestion.data.kind == 'instantiation' or suggestion.data.kind == 'static'
+            editor.transact () =>
+                linesAdded = parser.addUseClass(editor, suggestion.text, config.config.insertNewlinesForUseStatements)

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,5 +1,6 @@
 fs = require 'fs'
 namespace = require './services/namespace.coffee'
+useStatement = require './services/use-statement.coffee'
 StatusInProgress = require "./services/status-in-progress.coffee"
 StatusErrorAutocomplete = require "./services/status-error-autocomplete.coffee"
 
@@ -101,6 +102,10 @@ module.exports =
         # Command for namespaces
         atom.commands.add 'atom-workspace', 'atom-autocomplete-php:namespace': =>
             namespace.createNamespace(atom.workspace.getActivePaneItem())
+
+        # Command for importing use statement
+        atom.commands.add 'atom-workspace', 'atom-autocomplete-php:import-use-statement': =>
+            useStatement.importUseStatement(atom.workspace.getActivePaneItem())
 
         # Command to test configuration
         atom.commands.add 'atom-workspace', 'atom-autocomplete-php:configuration': =>

--- a/lib/services/use-statement.coffee
+++ b/lib/services/use-statement.coffee
@@ -1,0 +1,36 @@
+###*
+ * PHP import use statement
+###
+
+module.exports =
+
+    ###*
+     * Import use statement for class under cursor
+     * @param {TextEditor} editor
+    ###
+    importUseStatement: (editor) ->
+        ClassProvider = require '../autocompletion/class-provider.coffee'
+        provider = new ClassProvider()
+        word = editor.getWordUnderCursor()
+        regex = new RegExp('\\\\' + word + '$');
+
+        suggestions = provider.fetchSuggestionsFromWord(word)
+        return unless suggestions
+
+        suggestions = suggestions.filter((suggestion) ->
+            return suggestion.text == word || regex.test(suggestion.text)
+        )
+
+        return unless suggestions.length
+
+        if suggestions.length < 2
+            return provider.onSelectedClassSuggestion {editor, suggestion: suggestions.shift()}
+
+        ClassListView = require '../views/class-list-view'
+
+        return new ClassListView(suggestions, ({name}) ->
+            suggestion = suggestions.filter((suggestion) ->
+                return suggestion.text == name
+            ).shift()
+            provider.onSelectedClassSuggestion {editor, suggestion}
+        )

--- a/lib/views/class-list-view.coffee
+++ b/lib/views/class-list-view.coffee
@@ -1,0 +1,33 @@
+{$$, SelectListView} = require 'atom-space-pen-views'
+
+module.exports =
+
+class ClassListView extends SelectListView
+    initialize: (@suggestions, @onConfirm) ->
+        super
+        @show()
+        @setItems @suggestions.map((suggestion) ->
+            return {name: suggestion.text}
+        )
+        @focusFilterEditor()
+        @currentPane = atom.workspace.getActivePane()
+
+    getFilterKey: -> 'name'
+
+    show: ->
+        @panel ?= atom.workspace.addModalPanel(item: this)
+        @panel.show()
+        @storeFocusedElement()
+
+    cancelled: -> @hide()
+
+    hide: -> @panel?.destroy()
+
+    viewForItem: ({name}) ->
+        $$ ->
+            @li name
+
+    confirmed: (item) ->
+        @onConfirm(item)
+        @cancel()
+        @currentPane.activate() if @currentPane?.isAlive()


### PR DESCRIPTION
This commit adds a new "Import Use Statement" command that can be triggered any time. It uses as much of the existing autocompletion code as possible, but fetches suggestions for the word under the cursor. 