### PR TITLE
Add config setting to ensure new line after namespace

### DIFF
--- a/lib/autocompletion/class-provider.coffee
+++ b/lib/autocompletion/class-provider.coffee
@@ -128,7 +128,7 @@ class ClassProvider extends AbstractProvider
 
         if suggestion.data.kind == 'instantiation' or suggestion.data.kind == 'static'
             editor.transact () =>
-                linesAdded = parser.addUseClass(editor, suggestion.text, config.config.insertNewlinesForUseStatements)
+                linesAdded = parser.addUseClass(editor, suggestion.text, config.config.insertNewlinesForUseStatements, config.config.ensureNewLineAfterNamespace)
 
                 # Removes namespace from classname
                 if linesAdded != null
@@ -160,4 +160,4 @@ class ClassProvider extends AbstractProvider
 
         if suggestion.data.kind == 'instantiation' or suggestion.data.kind == 'static'
             editor.transact () =>
-                linesAdded = parser.addUseClass(editor, suggestion.text, config.config.insertNewlinesForUseStatements)
+                linesAdded = parser.addUseClass(editor, suggestion.text, config.config.insertNewlinesForUseStatements, config.config.ensureNewLineAfterNamespace)

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -27,6 +27,7 @@ module.exports =
         @config['packagePath'] = atom.packages.resolvePackagePath('atom-autocomplete-php')
         @config['verboseErrors'] = atom.config.get('atom-autocomplete-php.verboseErrors')
         @config['insertNewlinesForUseStatements'] = atom.config.get('atom-autocomplete-php.insertNewlinesForUseStatements')
+        @config['ensureNewLineAfterNamespace'] = atom.config.get('atom-autocomplete-php.ensureNewLineAfterNamespace')
 
     ###*
      * Writes configuration in "php lib" folder
@@ -140,4 +141,7 @@ module.exports =
             @writeConfig()
 
         atom.config.onDidChange 'atom-autocomplete-php.insertNewlinesForUseStatements', () =>
+            @writeConfig()
+
+        atom.config.onDidChange 'atom-autocomplete-php.ensureNewLineAfterNamespace', () =>
             @writeConfig()

--- a/lib/peekmo-php-atom-autocomplete.coffee
+++ b/lib/peekmo-php-atom-autocomplete.coffee
@@ -59,6 +59,13 @@ module.exports =
             default: false
             order: 6
 
+        ensureNewLineAfterNamespace:
+            title: 'Ensure new line after namespace.'
+            description: 'When enabled, the plugin will add a new line before the use statement when it comes directly after the namespace.'
+            type: 'boolean'
+            default: false
+            order: 6
+
         verboseErrors:
             title: 'Errors on file saving showed'
             description: 'When enabled, you\'ll have a notification once an error occured on autocomplete. Otherwise, the message will just be logged in developer console'

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -160,7 +160,7 @@ module.exports =
      * @return {int}       The amount of lines added (including newlines), so you can reliably and easily offset your
      *                     rows. This could be zero if a use statement was already present.
     ###
-    addUseClass: (editor, className, allowAdditionalNewlines) ->
+    addUseClass: (editor, className, allowAdditionalNewlines, ensureNewLineAfterNamespace) ->
         if className.split('\\').length == 1 or className.indexOf('\\') == 0
             return null
 
@@ -168,6 +168,7 @@ module.exports =
         bestScore = 0
         placeBelow = true
         doNewLine = true
+        namespaceLine = 0
         lineCount = editor.getLineCount()
 
         # Determine an appropriate location to place the use statement.
@@ -186,6 +187,7 @@ module.exports =
                 break
 
             if line.indexOf('namespace ') >= 0
+                namespaceLine = i
                 bestUse = i
 
             matches = @useStatementRegex.exec(line)
@@ -219,7 +221,7 @@ module.exports =
 
         textToInsert = ''
 
-        if doNewLine and placeBelow
+        if (doNewLine and placeBelow) || (ensureNewLineAfterNamespace and bestUse == namespaceLine)
             textToInsert += lineEnding
 
         textToInsert += "use #{className};" + lineEnding


### PR DESCRIPTION
Currently, when adding the first use statement in a file, the use statement is bumped up against the namespace with no new line. This commit adds a config option to ensure a new line between the namespace and the use statement.