### PR TITLE
Core functions tooltips + go to docs

### DIFF
--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -1,12 +1,15 @@
 {TextEditor} = require 'atom'
 
+opn = require 'opn'
+
 AbstractProvider = require './abstract-provider'
+config = require "../config.coffee"
 
 module.exports =
 
 class FunctionProvider extends AbstractProvider
-    hoverEventSelectors: '.syntax--function-call'
-    clickEventSelectors: '.syntax--function-call'
+    hoverEventSelectors: '.syntax--function-call, .syntax--function'
+    clickEventSelectors: '.syntax--function-call, .syntax--function'
     gotoRegex: /(?:(?:[a-zA-Z0-9_]*)\s*(?:\(.*\))?\s*(?:->|::)\s*)+([a-zA-Z0-9_]*)/
 
     ###*
@@ -34,12 +37,16 @@ class FunctionProvider extends AbstractProvider
         if not value
             return
 
-        atom.workspace.open(value.declaringStructure.filename, {
-            initialLine    : (value.startLine - 1),
-            searchAllPanes : true
-        })
+        if value.isInternal
+            opn(config.config.php_documentation_base_url.functions+term)
 
-        @manager.addBackTrack(editor.getPath(), bufferPosition)
+        else
+            atom.workspace.open(value.declaringStructure.filename, {
+                initialLine    : (value.startLine - 1),
+                searchAllPanes : true
+            })
+
+            @manager.addBackTrack(editor.getPath(), bufferPosition)
 
     ###*
      * Gets the regex used when looking for a word within the editor

--- a/lib/tooltip/function-provider.coffee
+++ b/lib/tooltip/function-provider.coffee
@@ -6,7 +6,7 @@ AbstractProvider = require './abstract-provider'
 module.exports =
 
 class FunctionProvider extends AbstractProvider
-    hoverEventSelectors: '.syntax--function-call'
+    hoverEventSelectors: '.syntax--function-call, .syntax--function'
 
     ###*
      * Retrieves a tooltip for the word given.

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     }
   },
   "dependencies": {
+    "atom-space-pen-views": "~2.0.5",
     "fuzzaldrin": "^2.1.0",
-    "md5": "2.0.0",
-    "sub-atom": "~1.0.0",
     "jquery": "~2.1.4",
-    "atom-space-pen-views": "~2.0.5"
+    "md5": "2.0.0",
+    "opn": "^5.1.0",
+    "sub-atom": "~1.0.0"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
This shows tooltips for php core functions and allows clicking through to the php docs page. Previously, the behaviour for me was opening an undefined page on click.