### PR TITLE
Sort namespace insertion by length if grouping is not used

### DIFF
--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -251,7 +251,6 @@ module.exports =
      * Returns a boolean indicating if the specified class shares
      * a common namespace prefix with other use statements.
      *
-     * @param {string} editor
      * @param {TextEditor} editor                  Atom text editor.
      * @param {string}     className               Name of the class to check against.
      *

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -165,7 +165,7 @@ module.exports =
             return null
 
         bestUse = 0
-        firstUse = 0;
+        firstUse = 0
         bestScore = 0
         placeBelow = true
         doNewLine = true
@@ -204,12 +204,12 @@ module.exports =
                     doNewLine = false
 
                     if (firstUse == 0)
-                        firstUse = bestUse = i;
-                        placeBelow = false;
+                        firstUse = bestUse = i
+                        placeBelow = false
 
                     if className.length >= matches[1].length
-                        bestUse = i;
-                        placeBelow = true;
+                        bestUse = i
+                        placeBelow = true
 
                 else if score >= bestScore
                     bestUse = i


### PR DESCRIPTION
If a common namespace prefix is not found and the user does not want to insert new lines for additional groupings (Config setting: Insert newlines for use statements), then the use statement will be inserted based on character length to ensure the use statements are sorted properly instead of having a shorter use statement fall to the bottom.