### PR TITLE
ErrorHandler: Renaming \Exception to \Throwable because PHP 7 throws Errors to

### DIFF
--- a/php/ErrorHandler.php
+++ b/php/ErrorHandler.php
@@ -40,9 +40,9 @@ class ErrorHandler
     /**
      * Display uncaught exception in JSON.
      *
-     * @param \Exception $exception
+     * @param \Throwable $exception
      */
-    public static function onException(\Exception $exception)
+    public static function onException(\Throwable $exception)
     {
         die(
             json_encode(


### PR DESCRIPTION
At `Peekmo\AtomAutocompletePhp\ErrorHandler` there's a method called `onException` that was expecting a `\Exception` object to display the message and die.

Since PHP 7, errors are thrown too, but as an `\Error` class. Both `\Exception` and `\Error` classes implement a `\Throwable` interface. To make the code more compliant and avoid Fatal Errors due to an unexpected type received, I'm renaming `\Exception` to `\Throwable` in that method.