### PR TITLE
Fixes for recent PHP versions

### DIFF
--- a/php/ErrorHandler.php
+++ b/php/ErrorHandler.php
@@ -29,12 +29,11 @@ class ErrorHandler
         set_exception_handler('Peekmo\AtomAutocompletePhp\ErrorHandler::onException');
     }
 
-    /**
-     * @throws ErrorException on any error.
-     */
     public static function onError($code, $message, $file, $line, $context)
     {
-        throw new \ErrorException($message, $code, 1, $file, $line);
+        // call onException directly instead of throw'ing
+        // to work around https://bugs.php.net/bug.php?id=66216
+        self::onException(new \ErrorException($message, $code, 1, $file, $line));
     }
 
     /**

--- a/php/ErrorHandler.php
+++ b/php/ErrorHandler.php
@@ -40,9 +40,9 @@ class ErrorHandler
     /**
      * Display uncaught exception in JSON.
      *
-     * @param \Exception $exception
+     * @param \Throwable $exception
      */
-    public static function onException(\Exception $exception)
+    public static function onException(\Throwable $exception)
     {
         die(
             json_encode(

--- a/php/services/Tools.php
+++ b/php/services/Tools.php
@@ -212,7 +212,7 @@ abstract class Tools
         );
 
         $result['return']['type'] = method_exists($function, 'getReturnType') && $function->hasReturnType() // PHP7
-            ? $function->getReturnType()->__toString()
+            ? (version_compare(PHP_VERSION, '7.1.0', '>=') ? $function->getReturnType()->getName() : $function->getReturnType()->__toString())
             : $result['return']['type']
         ;
 


### PR DESCRIPTION
This fixes some issues with recent versions of PHP:

* [#66216 of PHP](https://bugs.php.net/bug.php?id=66216) could lead to unhandled exceptions resulting in invalid JSON resulting in broken file parsing
* PHP 7+ will also throw `\Error`s so `ErrorHandler::onException` needs to accept `\Throwable`s too, see #402 / thx @vcampitelli
* [`ReflectionNamedType::__toString()`](https://www.php.net/manual/en/reflectiontype.tostring.php) was deprecated in PHP 7.1.0 in favor of [`ReflectionNamedType::getName()`](https://www.php.net/manual/en/reflectionnamedtype.getname.php)

resolves #402 (by including it)
resolves #417 
fixes #412 
fixes #415 
