### PR TITLE
Fixes for recent language-php package

### DIFF
--- a/lib/goto/class-provider.coffee
+++ b/lib/goto/class-provider.coffee
@@ -3,8 +3,8 @@ AbstractProvider = require './abstract-provider'
 module.exports =
 
 class ClassProvider extends AbstractProvider
-    hoverEventSelectors: '.syntax--entity.syntax--inherited-class, .syntax--support.syntax--namespace, .syntax--support.syntax--class, .syntax--comment-clickable .syntax--region'
-    clickEventSelectors: '.syntax--entity.syntax--inherited-class, .syntax--support.syntax--namespace, .syntax--support.syntax--class'
+    hoverEventSelectors: '.syntax--entity.syntax--inherited-class, .syntax--support.syntax--namespace, .syntax--support.syntax--class, .syntax--typehinted .syntax--type, .syntax--comment-clickable .syntax--region'
+    clickEventSelectors: '.syntax--entity.syntax--inherited-class, .syntax--support.syntax--namespace, .syntax--support.syntax--class, .syntax--typehinted .syntax--type'
     gotoRegex: /^\\?[A-Z][A-za-z0-9_]*(\\[A-Z][A-Za-z0-9_])*$/
 
     ###*

--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -5,8 +5,8 @@ AbstractProvider = require './abstract-provider'
 module.exports =
 
 class FunctionProvider extends AbstractProvider
-    hoverEventSelectors: '.syntax--function-call'
-    clickEventSelectors: '.syntax--function-call'
+    hoverEventSelectors: '.syntax--function-call .syntax--function, .syntax--method-call .syntax--function'
+    clickEventSelectors: '.syntax--function-call .syntax--function, .syntax--method-call .syntax--function'
     gotoRegex: /(?:(?:[a-zA-Z0-9_]*)\s*(?:\(.*\))?\s*(?:->|::)\s*)+([a-zA-Z0-9_]*)/
 
     ###*

--- a/lib/goto/function-provider.coffee
+++ b/lib/goto/function-provider.coffee
@@ -7,7 +7,7 @@ module.exports =
 class FunctionProvider extends AbstractProvider
     hoverEventSelectors: '.syntax--function-call .syntax--function, .syntax--method-call .syntax--function'
     clickEventSelectors: '.syntax--function-call .syntax--function, .syntax--method-call .syntax--function'
-    gotoRegex: /(?:(?:[a-zA-Z0-9_]*)\s*(?:\(.*\))?\s*(?:->|::)\s*)+([a-zA-Z0-9_]*)/
+    gotoRegex: /(?:(?:[a-zA-Z0-9_]*)\s*(?:\(.*\))?\s*(?:->|::)\s*)+([a-zA-Z0-9_]*)\(/
 
     ###*
      * Goto the class from the term given.

--- a/lib/goto/property-provider.coffee
+++ b/lib/goto/property-provider.coffee
@@ -5,8 +5,8 @@ AbstractProvider = require './abstract-provider'
 module.exports =
 
 class PropertyProvider extends AbstractProvider
-    hoverEventSelectors: '.syntax--property'
-    clickEventSelectors: '.syntax--property'
+    hoverEventSelectors: '.syntax--property, .syntax--class.syntax--operator + .syntax--constant'
+    clickEventSelectors: '.syntax--property, .syntax--class.syntax--operator + .syntax--constant'
     gotoRegex: /^(\$\w+)?((->|::)\w+)+/
 
     ###*
@@ -34,7 +34,7 @@ class PropertyProvider extends AbstractProvider
         if not value
             return
 
-        atom.workspace.open(value.declaringStructure.filename, {
+        atom.workspace.open((value.declaringStructure || value.declaringClass).filename, {
             searchAllPanes: true
         })
 

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -709,7 +709,7 @@ module.exports =
         # If there are multiple matches, just select the first method.
         if value instanceof Array
             for val in value
-                if val.isMethod
+                if val.isMethod || val.isStatic
                     return val
                     break
             # return undefined if we didn't find a matching element

--- a/lib/services/php-file-parser.coffee
+++ b/lib/services/php-file-parser.coffee
@@ -710,8 +710,10 @@ module.exports =
         if value instanceof Array
             for val in value
                 if val.isMethod
-                    value = val
+                    return val
                     break
+            # return undefined if we didn't find a matching element
+            return
 
         return value
 

--- a/lib/tooltip/class-provider.coffee
+++ b/lib/tooltip/class-provider.coffee
@@ -6,7 +6,7 @@ AbstractProvider = require './abstract-provider'
 module.exports =
 
 class ClassProvider extends AbstractProvider
-    hoverEventSelectors: '.syntax--entity.syntax--inherited-class, .syntax--support.syntax--namespace, .syntax--support.syntax--class, .syntax--comment-clickable .syntax--region'
+    hoverEventSelectors: '.syntax--entity.syntax--inherited-class, .syntax--support.syntax--namespace, .syntax--support.syntax--class, .syntax--typehinted .syntax--type, .syntax--comment-clickable .syntax--region'
 
     ###*
      * Retrieves a tooltip for the word given.

--- a/lib/tooltip/function-provider.coffee
+++ b/lib/tooltip/function-provider.coffee
@@ -6,7 +6,7 @@ AbstractProvider = require './abstract-provider'
 module.exports =
 
 class FunctionProvider extends AbstractProvider
-    hoverEventSelectors: '.syntax--function-call'
+    hoverEventSelectors: '.syntax--function-call .syntax--function, .syntax--method-call .syntax--function'
 
     ###*
      * Retrieves a tooltip for the word given.

--- a/lib/tooltip/property-provider.coffee
+++ b/lib/tooltip/property-provider.coffee
@@ -5,7 +5,7 @@ AbstractProvider = require './abstract-provider'
 module.exports =
 
 class PropertyProvider extends AbstractProvider
-    hoverEventSelectors: '.syntax--property'
+    hoverEventSelectors: '.syntax--property, .syntax--class.syntax--operator + .syntax--constant'
 
     ###*
      * Retrieves a tooltip for the word given.


### PR DESCRIPTION
Since the last update of this package in 2017 the https://github.com/atom/language-php package has undergone significant changes breaking the functionality of `atom-autocomplete-php`. This is mostly to a changed structure / naming of CSS selectors / syntax scopes.

This PR updates appropriately to make `atom-autocomplete-php` work with a recent `language-php` / `atom` version.